### PR TITLE
Fix conversion default, library filter, and engine auto-update

### DIFF
--- a/Jellyfin.Plugin.Lapse/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lapse/Configuration/configPage.html
@@ -14,7 +14,6 @@
                     <h1>LAPSE</h1>
                     <span class="fieldDescription">Sync subtitles that have drifted out of time</span>
                 </div>
-                <div id="lapseEngineStates" class="lapseEngineStates"></div>
             </div>
 
             <div class="lapseWarningStrip hide" id="lapseInjectionWarning"></div>

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
@@ -27,25 +27,6 @@
     margin: 0 0 .1em 0;
 }
 
-.lapseEngineStates {
-    display: flex;
-    gap: .9em;
-    flex-wrap: wrap;
-    font-size: .85em;
-    opacity: .85;
-}
-
-.lapseEngineState {
-    display: flex;
-    align-items: center;
-    gap: .35em;
-    white-space: nowrap;
-}
-
-.lapseEngineState-broken {
-    color: #d84343;
-}
-
 .lapseMuted {
     opacity: .6;
 }

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
@@ -195,6 +195,18 @@
         return div.innerHTML;
     }
 
+    // Two ids for the same thing, compared without caring how they were written. Guids
+    // reach the browser dashed from some endpoints and undashed from others depending on
+    // how the server serialised them, and a plain === between the two forms silently
+    // matches nothing.
+    function sameId(a, b) {
+        if (!a || !b) {
+            return false;
+        }
+
+        return String(a).replace(/-/g, '').toLowerCase() === String(b).replace(/-/g, '').toLowerCase();
+    }
+
     function findEngine(id) {
         for (var i = 0; i < allEngines.length; i++) {
             if (allEngines[i].Id === id) {
@@ -430,10 +442,21 @@
             engineProblem = '<div class="lapseEngineError">Not installed. Install it under Settings, Engines.</div>';
         } else if (engine && engine.RunCheckError) {
             engineProblem = '<div class="lapseEngineError">' + escapeHtml(engine.RunCheckError) + '</div>';
-        } else if (engine && engine.UpdateAvailable && engine.LatestVersion) {
-            engineProblem = '<div class="lapseEngineVersion">' + escapeHtml(engine.LatestVersion) +
-                ' is out. Update it under Settings, Engines.</div>';
         }
+
+        // An update is worth acting on where it is noticed, so the dashboard offers the
+        // button itself rather than sending people to Settings, Engines to press the same
+        // thing.
+        var updateAvailable = !!(engine && overview.ActiveEngineReady && !engine.RunCheckError && engine.UpdateAvailable);
+        if (updateAvailable) {
+            engineProblem = '<div class="lapseEngineVersion">' +
+                escapeHtml(engine.LatestVersion || 'A newer release') + ' is out.</div>';
+        }
+
+        var updateButton = updateAvailable
+            ? '      <button is="emby-button" type="button" class="raised button-submit lapseSmallButton" id="lapseUpdateEngine">' +
+              '<span>Update to ' + escapeHtml(engine.LatestVersion || 'the latest') + '</span></button>'
+            : '';
 
         var counts = countStatuses();
         var modeLabel = overview.ActiveEngineMode || '';
@@ -498,7 +521,9 @@
             '    <div class="lapseActiveEngineMode">' + escapeHtml(modeLabel) + ' mode</div>' +
             engineProblem +
             '    <div class="lapseHeroActions">' +
-            '      <button is="emby-button" type="button" class="raised button-submit lapseSmallButton" id="lapseGoBulk"><span>Sync everything</span></button>' +
+            updateButton +
+            '      <button is="emby-button" type="button" class="raised' + (updateAvailable ? '' : ' button-submit') +
+            ' lapseSmallButton" id="lapseGoBulk"><span>Sync everything</span></button>' +
             '      <button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseGoEngines"><span>Change engine</span></button>' +
             '    </div>' +
             '  </div>' +
@@ -515,6 +540,13 @@
 
             '<h3 class="lapseSubHeading">Recent activity</h3>' +
             recent;
+
+        var updateNow = container.querySelector('#lapseUpdateEngine');
+        if (updateNow) {
+            updateNow.addEventListener('click', function () {
+                updateEngine(view, engine.Id, updateNow);
+            });
+        }
 
         container.querySelector('#lapseGoBulk').addEventListener('click', function () {
             showPanel('lapsePanelBulk');
@@ -651,20 +683,6 @@
         }
 
         return '';
-    }
-
-    function renderEngineStates(view) {
-        view.querySelector('#lapseEngineStates').innerHTML = allEngines.map(function (engine) {
-            var cls = 'lapseEngineState';
-            if (engine.Installed && engine.RunCheckError) {
-                cls += ' lapseEngineState-broken';
-            }
-
-            return '<span class="' + cls + '">' +
-                escapeHtml(engine.DisplayName) + ' ' +
-                '<span class="lapseMuted">' + escapeHtml(engineStateText(engine)) + '</span>' +
-                '</span>';
-        }).join('');
     }
 
     // What the binary itself said it understands. ffsubsync alone lists about fifty flags,
@@ -1003,7 +1021,6 @@
     function refreshEngines(view) {
         return lapseGet('Lapse/Engines').then(function (engines) {
             allEngines = engines;
-            renderEngineStates(view);
             renderEngineCards(view);
             updateSubToSubEngineNote(view);
             view.querySelector('#lapseAutoUpdateEngines').checked =
@@ -1147,11 +1164,16 @@
         });
     }
 
+    // Only the libraries that are turned on, because those are the only ones the status
+    // list has any items from - offering a disabled library here just gives you a filter
+    // that can never match anything.
     function renderLibraryFilter(view) {
         var select = view.querySelector('#lapseItemLibraryFilter');
         var previous = select.value;
 
-        select.innerHTML = '<option value="">All libraries</option>' + allLibraries.map(function (library) {
+        select.innerHTML = '<option value="">All libraries</option>' + allLibraries.filter(function (library) {
+            return library.Enabled;
+        }).map(function (library) {
             return '<option value="' + library.ItemId + '">' + escapeHtml(library.Name) + '</option>';
         }).join('');
 
@@ -1400,7 +1422,7 @@
 
         var libraryId = view.querySelector('#lapseItemLibraryFilter').value;
         if (libraryId) {
-            shown = shown.filter(function (i) { return i.LibraryId === libraryId; });
+            shown = shown.filter(function (i) { return sameId(i.LibraryId, libraryId); });
         }
 
         var status = view.querySelector('#lapseItemStatusFilter').value;
@@ -2401,6 +2423,16 @@
     // No "Recommended" badges in here. Which format you want depends on what is going to
     // read the file, so the badge was telling people their own answer was the wrong one.
     // The sensible entry is still the one that comes pre-picked.
+    // srt on a fresh install, and srt again whenever the stored value is blank or is
+    // something this list doesn't offer. Leaving that to renderRadioGroup's generic
+    // fallback meant an unrecognised stored format landed on whichever entry happened to
+    // be first in the array rather than on the one this plugin actually defaults to.
+    function conversionFormat(stored) {
+        var value = String(stored || '').trim().replace(/^\./, '').toLowerCase();
+        var known = CONVERSION_FORMATS.some(function (f) { return f.value === value; });
+        return known ? value : 'srt';
+    }
+
     function renderConversion(view) {
         var settings = currentSettings || {};
         var plain = { hideRecommended: true };
@@ -2409,7 +2441,7 @@
             view.querySelector('#lapseConversionFormats'),
             'lapseConversionFormat',
             CONVERSION_FORMATS,
-            settings.ConversionFormat || 'srt',
+            conversionFormat(settings.ConversionFormat),
             function () { updateConversionHint(view); },
             plain);
 

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
@@ -761,20 +761,16 @@
         var select = overlay.querySelector('#lapseConvertSubtitle');
         var formatSelect = overlay.querySelector('#lapseConvertFormat');
 
-        // Default to something that isn't what the file already is, so the first press
-        // does something.
-        function pickDefaultFormat() {
-            var current = currentFormat();
-            formatSelect.value = current === 'srt' ? 'vtt' : 'srt';
-        }
-
         function currentFormat() {
             var match = /\.([a-z0-9]+)$/i.exec(select.value || '');
             return match ? match[1].toLowerCase() : '';
         }
 
-        select.addEventListener('change', pickDefaultFormat);
-        pickDefaultFormat();
+        // srt is what people convert to almost every time, so it is the standing default
+        // and stays selected unless it is deliberately changed. This used to pick whatever
+        // the file was not, which meant the common case - an srt that wants tidying up -
+        // opened on .vtt.
+        formatSelect.value = 'srt';
 
         overlay.querySelector('#lapseConvertCancel').addEventListener('click', function () {
             overlay.remove();

--- a/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
+++ b/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
@@ -201,10 +201,9 @@ public class LapseController : ControllerBase
     {
         var config = Plugin.Instance!.Configuration;
         var libraryNames = _libraryService.GetLibraries().ToDictionary(l => l.ItemId, l => l.Name);
-        var libraryIds = _libraryService.GetLibraryIdSet();
         var result = new List<ItemStatusEntry>();
 
-        foreach (var item in _libraryService.GetItems(includeSkipped: true))
+        foreach (var (item, libraryId) in _libraryService.GetItemsWithLibrary(includeSkipped: true))
         {
             var record = config.MovieRecords.FirstOrDefault(r => r.ItemId == item.Id);
             var subtitles = _subtitleLocator.GetExternalSubtitles(item);
@@ -217,15 +216,13 @@ public class LapseController : ControllerBase
                 : subtitles.Count(s => record.SyncedSubtitles
                     .Any(r => string.Equals(r.Path, s.Path, StringComparison.Ordinal)));
 
-            var libraryId = _libraryService.GetLibraryIdFor(item, libraryIds);
-
             result.Add(new ItemStatusEntry
             {
                 ItemId = item.Id,
                 Name = SyncQueueManager.DescribeItem(item),
                 ItemType = item.GetBaseItemKind().ToString(),
                 LibraryId = libraryId,
-                LibraryName = libraryId.HasValue && libraryNames.TryGetValue(libraryId.Value, out var name) ? name : null,
+                LibraryName = libraryNames.TryGetValue(libraryId, out var name) ? name : null,
                 Status = ResolveDisplayStatus(item, record, subtitles.Count, syncedCount),
                 LastSyncUtc = record?.LastSyncUtc,
                 LastError = record?.LastError,
@@ -1333,7 +1330,12 @@ public class LapseController : ControllerBase
             ConfidenceSigma = config.ConfidenceSigma,
             SubToSubPlacement = config.SubToSubPlacement,
             SubToSubCustomFolder = config.SubToSubCustomFolder,
-            ConversionFormat = config.ConversionFormat,
+            // srt is the default this ships with, so a config written before this setting
+            // existed - or one holding a format that is no longer offered - reads back as
+            // srt rather than leaving the dashboard to pick something for it.
+            ConversionFormat = SubtitleFormats.TryNormalizeOutputFormat(config.ConversionFormat, out var storedFormat)
+                ? storedFormat
+                : "srt",
             ConversionReplaceOriginal = config.ConversionReplaceOriginal,
             ConversionSyncAfter = config.ConversionSyncAfter,
             SubtitleAccess = config.SubtitleAccess,

--- a/Jellyfin.Plugin.Lapse/Engines/EngineUpdater.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineUpdater.cs
@@ -97,6 +97,12 @@ public class EngineUpdater
 
         status.VersionUnknown = installed && installedVersion is null;
         status.UpdateAvailable = installed
+
+            // A binary behind a path override is not ours to replace. Offering an update
+            // for one was worse than saying nothing: installing writes to the managed
+            // path, which is not the file being run, so the button appeared to do nothing
+            // and the same update kept being offered afterwards.
+            && string.IsNullOrWhiteSpace(settings.PathOverride)
             && engine.Descriptor.GetDownloadForThisMachine() is not null
             && latest is not null
 
@@ -209,7 +215,13 @@ public class EngineUpdater
                 {
                     results[engine.Descriptor.Id] = await UpdateAsync(engine, force: false, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (ex is HttpRequestException or NotSupportedException or IOException)
+
+                // Deliberately broad, short of cancellation. One engine that cannot be
+                // written (a read-only volume, a permissions problem, a half-extracted
+                // archive) used to throw straight out of the loop and take every engine
+                // after it down with it, so a single bad install quietly stopped the
+                // nightly update for everything else.
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogWarning(ex, "Auto-update failed for {Engine}", engine.Descriptor.DisplayName);
                     results[engine.Descriptor.Id] = "failed: " + ex.Message;

--- a/Jellyfin.Plugin.Lapse/Services/LibraryService.cs
+++ b/Jellyfin.Plugin.Lapse/Services/LibraryService.cs
@@ -114,9 +114,9 @@ public class LibraryService
     }
 
     /// <summary>
-    /// Finds which library an item belongs to, by walking up its parents until one of
-    /// them is a library root. Returns null for anything outside a library the plugin
-    /// can see, which includes items that have been removed since they were queued.
+    /// Finds which library an item belongs to. Returns null for anything outside a
+    /// library the plugin can see, which includes items that have been removed since they
+    /// were queued.
     /// </summary>
     /// <param name="item">The item.</param>
     /// <param name="libraryIds">A set from <see cref="GetLibraryIdSet"/>, or null to
@@ -131,6 +131,23 @@ public class LibraryService
             if (libraryIds.Contains(current.Id))
             {
                 return current.Id;
+            }
+        }
+
+        // The parent chain is the physical folder structure, and a library's
+        // CollectionFolder is not always on it - it depends on how the library's paths
+        // were set up. Jellyfin's own ancestor lookup is the reliable answer, and it is
+        // the same relation the item queries use, so falling back to it here keeps
+        // "which library is this in" agreeing with "which library did this come from".
+        //
+        // Without this, every caller downstream reads null and treats the item as being
+        // outside any library: auto-sync on a new file, the Radarr/Sonarr webhook and the
+        // library filter on the status list all quietly did nothing.
+        foreach (var folder in _libraryManager.GetCollectionFolders(item))
+        {
+            if (libraryIds.Contains(folder.Id))
+            {
+                return folder.Id;
             }
         }
 
@@ -212,38 +229,56 @@ public class LibraryService
     /// <returns>The items.</returns>
     public List<BaseItem> GetItems(Guid? libraryId = null, bool includeSkipped = false)
     {
-        var items = new List<BaseItem>();
+        var result = new List<BaseItem>();
 
-        if (libraryId.HasValue)
+        foreach (var entry in GetItemsWithLibrary(libraryId, includeSkipped))
         {
-            items.AddRange(QueryLibrary(libraryId.Value));
+            result.Add(entry.Item);
         }
-        else
-        {
-            foreach (var id in GetEnabledLibraryIds())
-            {
-                items.AddRange(QueryLibrary(id));
-            }
-        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The same walk as <see cref="GetItems"/>, but each item comes back paired with the
+    /// library it was found in.
+    ///
+    /// The pairing is taken from the query that produced the item rather than by walking
+    /// the item's parents afterwards. Both should agree, but the parent walk quietly
+    /// returns null whenever an item's ancestor chain doesn't lead back to a
+    /// CollectionFolder the plugin can see, and a null there is what left every row in the
+    /// status list unattributable - so the library filter matched nothing at all.
+    /// </summary>
+    /// <param name="libraryId">The library to look in, or null for all enabled ones.</param>
+    /// <param name="includeSkipped">True to include items marked as skip or ignore.</param>
+    /// <returns>The items, each with its library id.</returns>
+    public List<(BaseItem Item, Guid LibraryId)> GetItemsWithLibrary(Guid? libraryId = null, bool includeSkipped = false)
+    {
+        var searched = libraryId.HasValue
+            ? new List<Guid> { libraryId.Value }
+            : GetEnabledLibraryIds();
 
         // a library can appear under more than one virtual folder path, and Jellyfin will
         // happily hand back the same item twice for that
         var seen = new HashSet<Guid>();
-        var result = new List<BaseItem>();
+        var result = new List<(BaseItem Item, Guid LibraryId)>();
 
-        foreach (var item in items)
+        foreach (var id in searched)
         {
-            if (!seen.Add(item.Id))
+            foreach (var item in QueryLibrary(id))
             {
-                continue;
-            }
+                if (!seen.Add(item.Id))
+                {
+                    continue;
+                }
 
-            if (!includeSkipped && (SyncQueueManager.IsSkipped(item) || IsIgnored(item)))
-            {
-                continue;
-            }
+                if (!includeSkipped && (SyncQueueManager.IsSkipped(item) || IsIgnored(item)))
+                {
+                    continue;
+                }
 
-            result.Add(item);
+                result.Add((item, id));
+            }
         }
 
         return result;

--- a/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Plugin.Lapse.Services;
 /// external subtitle an item has - there's no UI in the background path to pick
 /// engine/mode/penalty/subtitle.
 /// </summary>
-public class SyncQueueManager
+public class SyncQueueManager : IDisposable
 {
     private readonly ILibraryManager _libraryManager;
     private readonly LibraryService _libraryService;
@@ -35,6 +35,14 @@ public class SyncQueueManager
     private readonly List<QueueItem> _items = new();
     private readonly Queue<Guid> _pending = new();
     private readonly HashSet<Guid> _queuedIds = new();
+
+    // Only one item is ever synced at a time. The worker loop is one caller; the
+    // scheduled task's RunBatchAsync is another, and it runs items itself rather than
+    // handing them to the worker so that Jellyfin's task runner has something to wait on.
+    // Nothing stopped those two overlapping, which meant a per-library schedule firing
+    // during the nightly run had both of them driving engines over the same library, and
+    // potentially over the same file.
+    private readonly SemaphoreSlim _runGate = new(1, 1);
     private Task? _worker;
     private string? _jobName;
     private string? _unitName;
@@ -379,7 +387,40 @@ public class SyncQueueManager
         }
     }
 
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the resources this holds.
+    /// </summary>
+    /// <param name="disposing">True when called from <see cref="Dispose()"/>.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _runGate.Dispose();
+        }
+    }
+
     private async Task<bool> ProcessOneAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        await _runGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            return await SyncOneAsync(itemId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _runGate.Release();
+        }
+    }
+
+    private async Task<bool> SyncOneAsync(Guid itemId, CancellationToken cancellationToken)
     {
         SetItemStatus(itemId, QueueItemStatus.Running);
 

--- a/Jellyfin.Plugin.Lapse/Tasks/EngineUpdateTask.cs
+++ b/Jellyfin.Plugin.Lapse/Tasks/EngineUpdateTask.cs
@@ -63,6 +63,15 @@ public class EngineUpdateTask : IScheduledTask, IConfigurableScheduledTask
             {
                 Type = TaskTriggerInfoType.DailyTrigger,
                 TimeOfDayTicks = TimeSpan.FromHours(4).Ticks
+            },
+
+            // A server that isn't up at 04:00 - anything on a desktop, anything that gets
+            // shut down overnight - would never see a new engine release on the daily
+            // trigger alone, which is most of what "auto-update doesn't seem to happen"
+            // turns out to be. Running once at startup covers those.
+            new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfoType.StartupTrigger
             }
         };
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="Jellyfin.Plugin.Lapse/Configuration/LAPSE.png" alt="LAPSE" width="420">
+<p align="center">
+  <img src="Jellyfin.Plugin.Lapse/Configuration/LAPSE.png" alt="LAPSE" width="420">
+</p>
 
 # LAPSE for Jellyfin
 


### PR DESCRIPTION
v1.5.0 shipped three bugs found right after release: the item-level Convert dialog defaulted to whatever format the file wasn't (so an existing .srt opened on .vtt) instead of the intended .srt default, the sync status library filter matched nothing because item-to-library resolution silently returned null whenever an item's parent chain didn't lead back to a CollectionFolder, and the engine auto-update task only ran on a daily 04:00 trigger so a server that's off overnight never updated. The library resolution bug also affected auto-sync on new files and the Radarr/Sonarr webhook, which share the same lookup.

Also adds a startup trigger for engine updates, guards against two sync jobs running over the same library at once, stops offering an update for engines behind a custom binary path, and centers the README banner image.