### PR TITLE
Support LAPSE 2.0.3's wider format list, make conversion optional, ad…

### DIFF
--- a/Jellyfin.Plugin.Lapse/Configuration/LibraryConfig.cs
+++ b/Jellyfin.Plugin.Lapse/Configuration/LibraryConfig.cs
@@ -32,6 +32,14 @@ public class LibraryConfig
     public bool Enabled { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether an item added to this library gets picked
+    /// up on its own, without waiting for the next scheduled run. On by default, which is
+    /// how the plugin has always behaved - a config written before this setting existed
+    /// has no element for it, so the initializer here is what such a library gets.
+    /// </summary>
+    public bool AutoSyncEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether this library gets synced on a schedule.
     /// </summary>
     public bool ScheduleEnabled { get; set; }

--- a/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
@@ -217,6 +217,42 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool ConversionSyncAfter { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether every subtitle is converted to
+    /// <see cref="ConversionFormat"/> before it gets synced, whether or not the engine
+    /// needed it. Off by default, because with LAPSE it buys nothing: LAPSE reads eleven
+    /// formats and writes each one back as itself. Worth turning on for an engine that
+    /// reads fewer, or when the goal is simply to end up with srt files everywhere.
+    /// </summary>
+    public bool ConvertBeforeSync { get; set; }
+
+    /// <summary>
+    /// Gets or sets what an unattended run does to each subtitle it finds: sync it,
+    /// convert it, or both. Applies to the scheduled task, the per-library schedules,
+    /// auto-sync on a new item, bulk runs and the webhook.
+    /// </summary>
+    public AutomationAction AutomationAction { get; set; } = AutomationAction.Sync;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether unattended runs also translate every
+    /// subtitle they touch into <see cref="AutoTranslateLanguage"/>. Experimental, and off
+    /// by default: a library's worth of subtitles is a great deal of text to put through a
+    /// translation API, and machine translation gets things wrong without saying so.
+    /// </summary>
+    public bool AutoTranslateEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language automatic translation targets, as a code like "da".
+    /// </summary>
+    public string? AutoTranslateLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a subtitle that already has a translation
+    /// in the target language is left alone. On by default, and worth leaving on: without
+    /// it every scheduled run retranslates the whole library and pays for it again.
+    /// </summary>
+    public bool AutoTranslateSkipExisting { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets who besides administrators may sync, shift, convert and translate the
     /// subtitles of an item they can see. Admin only until an admin opens it up.
     /// </summary>

--- a/Jellyfin.Plugin.Lapse/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lapse/Configuration/configPage.html
@@ -72,6 +72,10 @@
                             <span class="lapseNavLabel">Conversion</span>
                             <span class="lapseNavHint" id="lapseConversionHint"></span>
                         </button>
+                        <button type="button" class="lapseNavItem" data-panel="lapsePanelAutomation">
+                            <span class="lapseNavLabel">Automation</span>
+                            <span class="lapseNavHint" id="lapseAutomationHint"></span>
+                        </button>
                         <button type="button" class="lapseNavItem" data-panel="lapsePanelAccess">
                             <span class="lapseNavLabel">Access</span>
                             <span class="lapseNavHint" id="lapseAccessHint"></span>
@@ -138,8 +142,11 @@
                             syncing and nothing you have now can be lost.
                         </div>
                         <div class="fieldDescription lapseTightNote">
-                            Turn a library on to make everything in it eligible for syncing. A schedule syncs
-                            that library on its own frequency and time.
+                            Turn a library on to make everything in it eligible for syncing. "New items"
+                            picks up anything added to that library on its own, so a film you just added
+                            does not have to wait for the schedule. A schedule runs over the whole library
+                            on its own frequency and time. What either of them actually does to a subtitle
+                            is set on the <strong>Automation</strong> page.
                         </div>
                         <div id="lapseLibraryList" class="lapseLibraryList"></div>
                         <button is="emby-button" type="button" id="btnSaveLibraries" class="raised button-submit lapseSmallButton">
@@ -316,21 +323,77 @@
                             for converted ones.
                         </div>
 
+                        <div class="lapseNoteStrip" id="lapseConversionEngineNote"></div>
+
                         <h3 class="lapseSubHeading">Convert to</h3>
                         <div id="lapseConversionFormats" class="lapseRadioGroup"></div>
 
                         <h3 class="lapseSubHeading">What happens to the file it read</h3>
                         <div id="lapseConversionOriginal" class="lapseRadioGroup"></div>
 
+                        <h3 class="lapseSubHeading">Before syncing</h3>
+                        <div class="fieldDescription lapseTightNote">
+                            The plugin converts a subtitle on its own when the engine cannot read the
+                            format, and only then. This is for when you want it done anyway.
+                        </div>
+                        <div id="lapseConvertBeforeSync" class="lapseRadioGroup"></div>
+
                         <h3 class="lapseSubHeading">When a subtitle has to be converted before it can be synced</h3>
                         <div class="fieldDescription lapseTightNote">
-                            Some formats no engine reads at all, MicroDVD and SAMI among them. Those get
-                            turned into a format that works before anything else can happen.
+                            Applies when you press Convert on a subtitle the engine cannot read.
                         </div>
                         <div id="lapseConversionSync" class="lapseRadioGroup"></div>
 
                         <button is="emby-button" type="button" id="btnSaveConversion" class="raised button-submit lapseSmallButton">
                             <span>Save conversion settings</span>
+                        </button>
+                    </section>
+
+                    <section class="lapsePanel" id="lapsePanelAutomation">
+                        <h2 class="lapsePanelTitle">Automation</h2>
+                        <div class="fieldDescription lapseTightNote">
+                            What runs nobody is watching do to the subtitles they find: the scheduled task,
+                            the per-library schedules, a newly added item, a bulk run, and the
+                            Radarr/Sonarr webhook. Pressing Sync or Convert on a single item is not
+                            affected by anything on this page.
+                        </div>
+
+                        <h3 class="lapseSubHeading">What an automatic run does</h3>
+                        <div id="lapseAutomationActions" class="lapseRadioGroup"></div>
+
+                        <h3 class="lapseSubHeading">Automatic translation</h3>
+                        <div class="lapseNoteStrip">
+                            <strong>Experimental.</strong> This puts every subtitle an automatic run
+                            touches through a translation provider. A library is a lot of text, so check
+                            what your API allows and what it costs before turning this on. Machine
+                            translation also gets things wrong without saying so, so keep File output on
+                            one of the backup modes and keep your originals. Translations are written to a
+                            new file and never replace the subtitle they were made from.
+                        </div>
+                        <label class="emby-checkbox-label lapseStackedCheck">
+                            <input id="lapseAutoTranslateEnabled" type="checkbox" is="emby-checkbox" />
+                            <span>Translate subtitles automatically</span>
+                        </label>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="lapseAutoTranslateLanguage">Translate into</label>
+                            <input is="emby-input" id="lapseAutoTranslateLanguage" type="text" placeholder="da" />
+                            <div class="fieldDescription">
+                                A language code, such as da, de or es. The provider is whichever one is
+                                picked on the Translation page. Leave this empty to keep automatic
+                                translation off.
+                            </div>
+                        </div>
+                        <label class="emby-checkbox-label lapseStackedCheck">
+                            <input id="lapseAutoTranslateSkipExisting" type="checkbox" is="emby-checkbox" />
+                            <span>Skip subtitles that already have a translation in that language</span>
+                        </label>
+                        <div class="fieldDescription lapseTightNote">
+                            Worth leaving on. Without it every scheduled run translates the whole library
+                            again and pays for it again.
+                        </div>
+
+                        <button is="emby-button" type="button" id="btnSaveAutomation" class="raised button-submit lapseSmallButton">
+                            <span>Save automation settings</span>
                         </button>
                     </section>
 

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
@@ -87,6 +87,41 @@
         }
     ];
 
+    var CONVERT_BEFORE_SYNC_MODES = [
+        {
+            value: 'off',
+            label: 'Only when the engine cannot read the format',
+            recommended: true,
+            note: 'LAPSE reads and writes eleven formats, so with it there is usually nothing to convert. ' +
+                'The file keeps the format it came in and you end up with one file instead of two.'
+        },
+        {
+            value: 'on',
+            label: 'Always convert first',
+            note: 'Every subtitle is written out in the format above before it is synced. Useful with an engine ' +
+                'that reads fewer formats, or when you simply want srt files everywhere. The original is left where it is.'
+        }
+    ];
+
+    var AUTOMATION_ACTIONS = [
+        {
+            value: 'Sync',
+            label: 'Sync them',
+            recommended: true,
+            note: 'Lines the subtitles up and leaves their format alone.'
+        },
+        {
+            value: 'ConvertThenSync',
+            label: 'Convert them, then sync them',
+            note: 'Writes each subtitle out in the conversion format first, then syncs that file.'
+        },
+        {
+            value: 'Convert',
+            label: 'Only convert them',
+            note: 'Changes the format and stops there. Nothing gets synced, so items stay marked as not synced.'
+        }
+    ];
+
     var ACCESS_MODES = [
         {
             value: 'AdminsOnly',
@@ -816,6 +851,29 @@
             '</div>';
     }
 
+    // Which subtitle formats this engine takes as they are. Read off the installed binary
+    // where it can say, so it is the truth about the build on disk rather than a claim.
+    function engineFormatsLine(engine) {
+        var formats = engine.SubtitleExtensions || [];
+
+        if (formats.length === 0) {
+            return '';
+        }
+
+        return '<div class="fieldDescription lapseParamNote">Reads and writes ' +
+            escapeHtml(formats.join(', ')) + '. Anything else is converted first.</div>';
+    }
+
+    function engineDeploymentHtml(engine) {
+        if (!engine.DeploymentNote) {
+            return '';
+        }
+
+        return '<div class="fieldDescription lapseParamNote">' + escapeHtml(engine.DeploymentNote) +
+            ' <a is="emby-linkbutton" class="button-link" href="' + escapeHtml(engine.ProjectUrl) +
+            '" target="_blank" rel="noopener">Read more on GitHub</a></div>';
+    }
+
     function renderEngineCards(view) {
         var container = view.querySelector('#lapseEngineCards');
 
@@ -891,9 +949,11 @@
                 '    <span>' + escapeHtml(updateNote || engineStateText(engine)) + '</span>' +
                 '  </div>' +
                 whyLink +
+                engineFormatsLine(engine) +
                 problem +
                 '  <div class="lapseEngineActions">' + actions + '</div>' +
                 engineAdvancedHtml(engine) +
+                engineDeploymentHtml(engine) +
                 '</div>';
         }).join('');
 
@@ -1023,6 +1083,7 @@
             allEngines = engines;
             renderEngineCards(view);
             updateSubToSubEngineNote(view);
+            renderConversionEngineNote(view);
             view.querySelector('#lapseAutoUpdateEngines').checked =
                 allEngines.length > 0 ? !!allEngines[0].AutoUpdate : true;
         });
@@ -1073,6 +1134,10 @@
                 '    <span class="lapseMuted lapseLibraryType">' + escapeHtml(library.CollectionType || 'mixed') + '</span>' +
                 '  </div>' +
                 '  <div class="lapseLibrarySchedule">' +
+                '    <label class="emby-checkbox-label lapseInlineCheck" title="Sync anything added to this library as it turns up, without waiting for the schedule.">' +
+                '      <input type="checkbox" is="emby-checkbox" class="lapseChkAutoSync"' + (library.AutoSyncEnabled !== false ? ' checked' : '') + ' />' +
+                '      <span>New items</span>' +
+                '    </label>' +
                 '    <label class="emby-checkbox-label lapseInlineCheck">' +
                 '      <input type="checkbox" is="emby-checkbox" class="lapseChkSchedule"' + (library.ScheduleEnabled ? ' checked' : '') + ' />' +
                 '      <span>Schedule</span>' +
@@ -1088,6 +1153,7 @@
 
         container.querySelectorAll('.lapseLibraryRow').forEach(function (row) {
             var scheduleCheck = row.querySelector('.lapseChkSchedule');
+            var autoSyncCheck = row.querySelector('.lapseChkAutoSync');
             var enabledCheck = row.querySelector('.lapseChkLibraryEnabled');
             var frequencySelect = row.querySelector('.lapseScheduleFrequency');
             var daySelect = row.querySelector('.lapseScheduleDay');
@@ -1101,6 +1167,7 @@
                 var needsDay = scheduled && frequencySelect.value !== 'Daily';
 
                 scheduleCheck.disabled = !enabledCheck.checked;
+                autoSyncCheck.disabled = !enabledCheck.checked;
 
                 frequencySelect.classList.toggle('hide', !scheduled);
                 timeInput.classList.toggle('hide', !scheduled);
@@ -1141,6 +1208,7 @@
             payload.Libraries.push({
                 ItemId: row.getAttribute('data-id'),
                 Enabled: row.querySelector('.lapseChkLibraryEnabled').checked,
+                AutoSyncEnabled: row.querySelector('.lapseChkAutoSync').checked,
                 ScheduleEnabled: row.querySelector('.lapseChkSchedule').checked,
                 ScheduleFrequency: frequency,
                 ScheduleDay: frequency === 'Daily' ? null : row.querySelector('.lapseScheduleDay').value,
@@ -2454,6 +2522,14 @@
             plain);
 
         renderRadioGroup(
+            view.querySelector('#lapseConvertBeforeSync'),
+            'lapseConvertBeforeSync',
+            CONVERT_BEFORE_SYNC_MODES,
+            settings.ConvertBeforeSync ? 'on' : 'off',
+            null,
+            plain);
+
+        renderRadioGroup(
             view.querySelector('#lapseConversionSync'),
             'lapseConversionSync',
             CONVERSION_SYNC_MODES,
@@ -2461,12 +2537,65 @@
             null,
             plain);
 
+        renderConversionEngineNote(view);
         updateConversionHint(view);
+    }
+
+    // Says which formats the engine in use actually reads, so "do I need to convert this"
+    // is answered on the page rather than guessed at.
+    function renderConversionEngineNote(view) {
+        var note = view.querySelector('#lapseConversionEngineNote');
+        if (!note) {
+            return;
+        }
+
+        var engine = allEngines.filter(function (e) { return e.IsDefault; })[0];
+        var formats = (engine && engine.SubtitleExtensions) || [];
+
+        if (!engine || formats.length === 0) {
+            note.classList.add('hide');
+            return;
+        }
+
+        note.classList.remove('hide');
+        note.innerHTML = '<strong>' + escapeHtml(engine.DisplayName) + '</strong> reads and writes ' +
+            escapeHtml(formats.join(', ')) + ', and writes each one back in the format it read. ' +
+            'Converting is therefore optional: the plugin only does it on its own when the engine ' +
+            'cannot read the file. It is still worth having if you use an engine that reads fewer ' +
+            'formats, or if you would rather have plain srt files across the library.';
     }
 
     function updateConversionHint(view) {
         view.querySelector('#lapseConversionHint').textContent =
             '.' + selectedRadio(view, 'lapseConversionFormat', 'srt');
+    }
+
+    function renderAutomation(view) {
+        var settings = currentSettings || {};
+
+        renderRadioGroup(
+            view.querySelector('#lapseAutomationActions'),
+            'lapseAutomationAction',
+            AUTOMATION_ACTIONS,
+            settings.AutomationAction || 'Sync',
+            function () { updateAutomationHint(view); },
+            { hideRecommended: true });
+
+        view.querySelector('#lapseAutoTranslateEnabled').checked = settings.AutoTranslateEnabled === true;
+        view.querySelector('#lapseAutoTranslateLanguage').value = settings.AutoTranslateLanguage || '';
+        view.querySelector('#lapseAutoTranslateSkipExisting').checked = settings.AutoTranslateSkipExisting !== false;
+
+        updateAutomationHint(view);
+    }
+
+    function updateAutomationHint(view) {
+        var action = selectedRadio(view, 'lapseAutomationAction', 'Sync');
+        var label = AUTOMATION_ACTIONS.filter(function (a) { return a.value === action; })[0];
+        var translating = view.querySelector('#lapseAutoTranslateEnabled').checked
+            && view.querySelector('#lapseAutoTranslateLanguage').value.trim();
+
+        view.querySelector('#lapseAutomationHint').textContent =
+            (label ? label.label : 'Sync them') + (translating ? ' + translate' : '');
     }
 
     function renderAccess(view) {
@@ -2581,6 +2710,7 @@
         renderAppearance(view);
         renderAccess(view);
         renderConversion(view);
+        renderAutomation(view);
         updateSidecarPreview(view);
 
         // the suggested name for a subtitle-to-subtitle output uses the sidecar suffix, so
@@ -2807,6 +2937,11 @@
             ConversionFormat: selectedRadio(view, 'lapseConversionFormat', 'srt'),
             ConversionReplaceOriginal: selectedRadio(view, 'lapseConversionOriginal', 'keep') === 'replace',
             ConversionSyncAfter: selectedRadio(view, 'lapseConversionSync', 'sync') === 'sync',
+            ConvertBeforeSync: selectedRadio(view, 'lapseConvertBeforeSync', 'off') === 'on',
+            AutomationAction: selectedRadio(view, 'lapseAutomationAction', 'Sync'),
+            AutoTranslateEnabled: view.querySelector('#lapseAutoTranslateEnabled').checked,
+            AutoTranslateLanguage: view.querySelector('#lapseAutoTranslateLanguage').value.trim() || null,
+            AutoTranslateSkipExisting: view.querySelector('#lapseAutoTranslateSkipExisting').checked,
             SubtitleAccessUserIds: selectedAccessUserIds(view),
             SidecarSuffix: view.querySelector('#lapseSidecarSuffix').value,
             LowConfidenceAction: selectedRadio(view, 'lapseLowConfidence', 'Sidecar'),
@@ -3052,6 +3187,15 @@
         });
         view.querySelector('#btnSaveConversion').addEventListener('click', function () {
             saveSettings(view, 'Conversion settings saved.');
+        });
+        view.querySelector('#btnSaveAutomation').addEventListener('click', function () {
+            saveSettings(view, 'Automation settings saved.');
+        });
+        view.querySelector('#lapseAutoTranslateEnabled').addEventListener('change', function () {
+            updateAutomationHint(view);
+        });
+        view.querySelector('#lapseAutoTranslateLanguage').addEventListener('input', function () {
+            updateAutomationHint(view);
         });
         view.querySelector('#btnSaveAccess').addEventListener('click', function () {
             saveSettings(view, 'Access settings saved.');

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
@@ -506,16 +506,18 @@
                 return;
             }
 
-            // Picture based tracks hold no text, so nothing here can line them up.
+            // Supported means the engine in use can do something with the file. LAPSE
+            // reads PGS and VobSub and rewrites their timing, so those are only turned
+            // away when the engine cannot read them.
             var usable = subtitles.filter(function (s) { return s.Supported !== false; });
 
             if (usable.length === 0) {
-                showLapseToast('The only subtitles on this item are picture based (PGS or VobSub). Those are images of text, so they need OCR before anything can sync them.');
+                showLapseToast('The only subtitles on this item are picture based (PGS or VobSub), and the engine you are using cannot read those. LAPSE can sync them, or run OCR over them with something like Subtitle Edit first.');
                 return;
             }
 
-            // Everything left is in a format no engine reads, but the plugin can convert
-            // it into one that they do. Worth offering rather than refusing.
+            // Everything left is in a format the engine does not read, but the plugin can
+            // convert it into one that it does. Worth offering rather than refusing.
             var syncable = usable.filter(function (s) { return !s.NeedsConversion; });
 
             if (syncable.length === 0) {
@@ -714,7 +716,9 @@
         showLapseToast('Checking subtitles...');
 
         lapseGet('Lapse/Items/' + context.id + '/Subtitles').then(function (subtitles) {
-            var convertible = subtitles.filter(function (s) { return s.Supported !== false; });
+            // Converting needs text, which a picture based subtitle has none of, whatever
+            // the engine can do with its timings.
+            var convertible = subtitles.filter(function (s) { return s.TextBased !== false; });
 
             if (convertible.length === 0) {
                 showLapseToast(subtitles.length === 0

--- a/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
+++ b/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
@@ -922,6 +922,7 @@ public class LapseController : ControllerBase
             var oldTime = library.ScheduleTime;
 
             library.Enabled = entry.Enabled;
+            library.AutoSyncEnabled = entry.AutoSyncEnabled;
             library.ScheduleEnabled = entry.ScheduleEnabled;
             library.ScheduleFrequency = Enum.TryParse<ScheduleFrequency>(entry.ScheduleFrequency, out var frequency)
                 ? frequency
@@ -1023,6 +1024,10 @@ public class LapseController : ControllerBase
                 WhyUrl = descriptor.WhyUrl,
                 WhyLabel = descriptor.WhyLabel,
                 AdvancedNote = descriptor.AdvancedNote,
+                DeploymentNote = descriptor.DeploymentNote,
+                SubtitleExtensions = installed
+                    ? runtime.GetSubtitleExtensions(descriptor.Id)
+                    : descriptor.Capabilities.SubtitleExtensions,
                 DownloadSupported = downloadable,
                 NoDownloadReason = downloadable ? null : EngineInstaller.DescribeMissingBuild(engine),
                 RunCheckError = installed ? await _runner.CheckRunnableAsync(engine, cancellationToken).ConfigureAwait(false) : null,
@@ -1338,6 +1343,11 @@ public class LapseController : ControllerBase
                 : "srt",
             ConversionReplaceOriginal = config.ConversionReplaceOriginal,
             ConversionSyncAfter = config.ConversionSyncAfter,
+            ConvertBeforeSync = config.ConvertBeforeSync,
+            AutomationAction = config.AutomationAction,
+            AutoTranslateEnabled = config.AutoTranslateEnabled,
+            AutoTranslateLanguage = config.AutoTranslateLanguage,
+            AutoTranslateSkipExisting = config.AutoTranslateSkipExisting,
             SubtitleAccess = config.SubtitleAccess,
             SubtitleAccessUserIds = new List<string>(config.SubtitleAccessUserIds),
             OpenSubtitlesEnabled = config.OpenSubtitlesEnabled,
@@ -1636,6 +1646,19 @@ public class LapseController : ControllerBase
             : "srt";
         config.ConversionReplaceOriginal = settings.ConversionReplaceOriginal;
         config.ConversionSyncAfter = settings.ConversionSyncAfter;
+        config.ConvertBeforeSync = settings.ConvertBeforeSync;
+        config.AutomationAction = settings.AutomationAction;
+        config.AutoTranslateEnabled = settings.AutoTranslateEnabled;
+        config.AutoTranslateLanguage = Blank(settings.AutoTranslateLanguage);
+        config.AutoTranslateSkipExisting = settings.AutoTranslateSkipExisting;
+
+        // Translating into nothing would run the whole library through a provider and
+        // write files named after an empty language tag, so it stays off until asked for.
+        if (string.IsNullOrEmpty(config.AutoTranslateLanguage))
+        {
+            config.AutoTranslateEnabled = false;
+        }
+
         config.SubtitleAccess = settings.SubtitleAccess;
 
         // Keep only ids that are still real users, so deleting a user doesn't leave a

--- a/Jellyfin.Plugin.Lapse/Data/AutomationAction.cs
+++ b/Jellyfin.Plugin.Lapse/Data/AutomationAction.cs
@@ -1,0 +1,31 @@
+// LAPSE Jellyfin Plugin
+// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Licensed under GPL v3 - see LICENSE for details
+
+namespace Jellyfin.Plugin.Lapse.Data;
+
+/// <summary>
+/// What a run nobody is watching does to the subtitles it finds. This covers the
+/// scheduled task, the per-library schedules, the auto-sync on a newly added item, the
+/// bulk runs and the Radarr/Sonarr webhook - everything that isn't a press on a button.
+/// </summary>
+public enum AutomationAction
+{
+    /// <summary>
+    /// Line the subtitles up and leave their format alone. The default, and with LAPSE
+    /// the only thing most libraries need: it reads and writes every common format, so
+    /// there's nothing to convert on the way past.
+    /// </summary>
+    Sync = 0,
+
+    /// <summary>
+    /// Only write the subtitles out in the conversion format, without syncing them.
+    /// For getting a library onto one format and doing the timing separately.
+    /// </summary>
+    Convert = 1,
+
+    /// <summary>
+    /// Convert to the conversion format, then sync the converted file.
+    /// </summary>
+    ConvertThenSync = 2
+}

--- a/Jellyfin.Plugin.Lapse/Data/EngineInfo.cs
+++ b/Jellyfin.Plugin.Lapse/Data/EngineInfo.cs
@@ -177,6 +177,22 @@ public class EngineInfo
     public string? AdvancedNote { get; set; }
 
     /// <summary>
+    /// Gets or sets a line about running this engine outside Jellyfin.
+    /// </summary>
+    public string? DeploymentNote { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subtitle formats this engine reads, as extensions with a leading
+    /// dot. Comes from the installed binary when it can say, otherwise from what the
+    /// plugin knows about the project.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage",
+        "CA2227:Collection properties should be read only",
+        Justification = "Built in one go from the engine descriptor or the runtime probe, and only ever serialized out to the dashboard.")]
+    public IReadOnlyList<string> SubtitleExtensions { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>
     /// Gets or sets a value indicating whether there's a build for this machine.
     /// </summary>
     public bool DownloadSupported { get; set; }

--- a/Jellyfin.Plugin.Lapse/Data/LibraryEntry.cs
+++ b/Jellyfin.Plugin.Lapse/Data/LibraryEntry.cs
@@ -33,6 +33,12 @@ public class LibraryEntry
     public bool Enabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether newly added items in this library are
+    /// picked up on their own, without waiting for a scheduled run.
+    /// </summary>
+    public bool AutoSyncEnabled { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether this library gets synced on a schedule.
     /// </summary>
     public bool ScheduleEnabled { get; set; }

--- a/Jellyfin.Plugin.Lapse/Data/LibrarySettingsRequest.cs
+++ b/Jellyfin.Plugin.Lapse/Data/LibrarySettingsRequest.cs
@@ -23,6 +23,12 @@ public class LibrarySettingsEntry
     public bool Enabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether newly added items in this library are
+    /// picked up on their own.
+    /// </summary>
+    public bool AutoSyncEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this library gets synced on a schedule.
     /// </summary>
     public bool ScheduleEnabled { get; set; }

--- a/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
+++ b/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
@@ -111,6 +111,32 @@ public class PluginSettings
     public bool ConversionSyncAfter { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether every subtitle is converted before syncing,
+    /// whether or not the engine needed it.
+    /// </summary>
+    public bool ConvertBeforeSync { get; set; }
+
+    /// <summary>
+    /// Gets or sets what unattended runs do to each subtitle.
+    /// </summary>
+    public AutomationAction AutomationAction { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether unattended runs also translate.
+    /// </summary>
+    public bool AutoTranslateEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language automatic translation targets.
+    /// </summary>
+    public string? AutoTranslateLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an existing translation is left alone.
+    /// </summary>
+    public bool AutoTranslateSkipExisting { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets who besides admins may sync, shift, convert and translate.
     /// </summary>
     public SubtitleAccessMode SubtitleAccess { get; set; }

--- a/Jellyfin.Plugin.Lapse/Data/SubtitleOption.cs
+++ b/Jellyfin.Plugin.Lapse/Data/SubtitleOption.cs
@@ -31,17 +31,25 @@ public class SubtitleOption
     public string Format { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether this file has to be converted to srt
-    /// before an engine can touch it. True for the text formats the engines don't read,
-    /// like MicroDVD .sub.
+    /// Gets or sets a value indicating whether this file has to be converted before an
+    /// engine can touch it. Depends on which engine: LAPSE reads MicroDVD .sub and eight
+    /// other formats directly, where alass and ffsubsync read none of them.
     /// </summary>
     public bool NeedsConversion { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the plugin can do anything with this file
-    /// at all. False for the picture based formats (PGS, VobSub), which hold no text.
+    /// at all - which now means "can it be synced", since a picture based subtitle has no
+    /// text but can still have its timing rewritten by an engine that reads the format.
     /// </summary>
     public bool Supported { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether there is text in this file the plugin can
+    /// get at. False for PGS and VobSub, which are pictures. Converting, translating and
+    /// shifting by hand all need this; syncing does not.
+    /// </summary>
+    public bool TextBased { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether this track is still inside the video file

--- a/Jellyfin.Plugin.Lapse/Engines/AlassEngine.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/AlassEngine.cs
@@ -133,7 +133,8 @@ public partial class AlassEngine : IEngine
                 SupportsPenalty = true,
                 DefaultPenalty = 7,
                 MinPenalty = 0,
-                MaxPenalty = 1000
+                MaxPenalty = 1000,
+                SubtitleExtensions = EngineFormats.Alass
             }
         };
 

--- a/Jellyfin.Plugin.Lapse/Engines/EngineCapabilities.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineCapabilities.cs
@@ -2,6 +2,8 @@
 // Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
 // Licensed under GPL v3 - see LICENSE for details
 
+using System.Collections.Generic;
+
 namespace Jellyfin.Plugin.Lapse.Engines;
 
 /// <summary>
@@ -58,4 +60,12 @@ public class EngineCapabilities
     /// Gets or sets the highest penalty the engine accepts.
     /// </summary>
     public int MaxPenalty { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subtitle formats this engine reads and writes, as extensions with
+    /// a leading dot. Anything not on here has to be converted before the engine sees it.
+    /// This is what the plugin knows about the project; the installed binary gets asked
+    /// directly as well, and its answer wins. See <see cref="EngineFormats"/>.
+    /// </summary>
+    public IReadOnlyList<string> SubtitleExtensions { get; set; } = EngineFormats.Ffsubsync;
 }

--- a/Jellyfin.Plugin.Lapse/Engines/EngineCapabilityProbe.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineCapabilityProbe.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -39,9 +40,14 @@ public partial class EngineCapabilityProbe
     [GeneratedRegex(@"\bv?(?<version>[0-9]+\.[0-9]+(\.[0-9]+)?)\b")]
     private static partial Regex VersionRegex();
 
+    // One subtitle extension on a line of its own, which is what --formats prints.
+    [GeneratedRegex(@"^\s*\*?\.?(?<extension>[a-z0-9]{2,5})\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex FormatLineRegex();
+
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(15);
     private static readonly string[] CapabilitiesArguments = { "--capabilities" };
     private static readonly string[] VersionArguments = { "--version" };
+    private static readonly string[] FormatsArguments = { "--formats" };
 
     private readonly ILogger<EngineCapabilityProbe> _logger;
     private readonly ConcurrentDictionary<string, EngineRuntimeInfo> _cache = new(StringComparer.Ordinal);
@@ -94,9 +100,16 @@ public partial class EngineCapabilityProbe
 
     private async Task<EngineRuntimeInfo> RunProbeAsync(string binaryPath, CancellationToken cancellationToken)
     {
+        // Which subtitle formats a binary reads decides whether the plugin has to convert
+        // a file before handing it over, so it's asked of every build rather than assumed
+        // from a version number. Engines with no such call just don't answer.
+        var formats = await TryFormatsCallAsync(binaryPath, cancellationToken).ConfigureAwait(false);
+
         var capabilities = await TryCapabilitiesCallAsync(binaryPath, cancellationToken).ConfigureAwait(false);
         if (capabilities is not null)
         {
+            capabilities.ReportedExtensions.AddRange(formats);
+
             _logger.LogInformation(
                 "{Path} answered --capabilities: version {Version}, flags {Flags}",
                 binaryPath,
@@ -116,6 +129,7 @@ public partial class EngineCapabilityProbe
         if (fromUsage is not null)
         {
             fromUsage.Version = version;
+            fromUsage.ReportedExtensions.AddRange(formats);
 
             _logger.LogDebug(
                 "{Path} has no --capabilities, read {Flags} out of its usage text instead (version {Version})",
@@ -125,16 +139,19 @@ public partial class EngineCapabilityProbe
             return fromUsage;
         }
 
-        if (version is not null)
+        if (version is not null || formats.Count > 0)
         {
             _logger.LogDebug("{Path} only answered --version ({Version}), sticking to the safe flags", binaryPath, version);
 
-            return new EngineRuntimeInfo
+            var partial = new EngineRuntimeInfo
             {
                 Probed = true,
                 Source = "version",
                 Version = version
             };
+
+            partial.ReportedExtensions.AddRange(formats);
+            return partial;
         }
 
         _logger.LogDebug("Could not work out what {Path} supports, falling back to the safe defaults", binaryPath);
@@ -164,6 +181,51 @@ public partial class EngineCapabilityProbe
 
         var match = VersionRegex().Match(text);
         return match.Success ? match.Groups["version"].Value : null;
+    }
+
+    // "engine --formats" prints one subtitle extension per line and exits 0. An engine
+    // that has no such call either errors out or prints its usage text, and neither of
+    // those is a list of extensions, so the strict line-by-line parse below is what tells
+    // a real answer from a refusal. Anything that doesn't parse cleanly returns nothing,
+    // and the caller falls back to the list the plugin knows the project by.
+    private async Task<List<string>> TryFormatsCallAsync(string binaryPath, CancellationToken cancellationToken)
+    {
+        var found = new List<string>();
+
+        var (stdout, _, exitCode, started) = await RunAsync(binaryPath, FormatsArguments, cancellationToken).ConfigureAwait(false);
+        if (!started || exitCode != 0 || string.IsNullOrWhiteSpace(stdout))
+        {
+            return found;
+        }
+
+        foreach (var line in stdout.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var match = FormatLineRegex().Match(line);
+            if (!match.Success)
+            {
+                // one line that isn't an extension means this wasn't a format list at all
+                _logger.LogDebug("{Path} answered --formats with something that isn't a format list, ignoring it", binaryPath);
+                return new List<string>();
+            }
+
+            var extension = "." + match.Groups["extension"].Value.ToLowerInvariant();
+            if (!found.Contains(extension, StringComparer.Ordinal))
+            {
+                found.Add(extension);
+            }
+        }
+
+        if (found.Count > 0)
+        {
+            _logger.LogInformation("{Path} reads {Formats}", binaryPath, string.Join(", ", found));
+        }
+
+        return found;
     }
 
     private static int CountLines(string text)

--- a/Jellyfin.Plugin.Lapse/Engines/EngineDescriptor.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineDescriptor.cs
@@ -239,6 +239,12 @@ public class EngineDescriptor
     public string? AdvancedNote { get; set; }
 
     /// <summary>
+    /// Gets or sets a line about running this engine outside Jellyfin, shown on the
+    /// engine card under the links.
+    /// </summary>
+    public string? DeploymentNote { get; set; }
+
+    /// <summary>
     /// Gets the alignment modes this engine can run in, in the order they should be
     /// offered. The first one is what a fresh install uses for the context menu's Sync
     /// button until someone picks something else.

--- a/Jellyfin.Plugin.Lapse/Engines/EngineFormats.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineFormats.cs
@@ -1,0 +1,130 @@
+// LAPSE Jellyfin Plugin
+// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Licensed under GPL v3 - see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Jellyfin.Plugin.Lapse.Engines;
+
+/// <summary>
+/// Which subtitle formats each engine reads and writes.
+///
+/// This used to be one list for all of them, because it used to be true: every engine
+/// took srt, vtt, ass or ssa and nothing else, so anything else had to be converted
+/// first. LAPSE 2.0.3 reads and writes nine more, including the two picture based ones,
+/// where it rewrites the timing without touching the bitmaps. Converting before syncing
+/// is therefore no longer something the plugin has to do, only something it can do.
+///
+/// The lists here are the fallback. When a binary is installed the plugin asks it with
+/// <c>--formats</c> and uses that answer instead, so a newer or older build than the one
+/// this was written against is still handled correctly. See
+/// <see cref="EngineRuntimeInfo.GetSubtitleExtensions"/>.
+/// </summary>
+public static class EngineFormats
+{
+    /// <summary>
+    /// What LAPSE 2.0.3 reads, taken from the subtitle_formats array in its main.cpp. It
+    /// writes back in whatever format it read, so nothing on this list needs converting
+    /// on the way in or on the way out.
+    /// </summary>
+    public static readonly string[] Lapse =
+    {
+        ".srt", ".ass", ".ssa", ".vtt", ".sub", ".sup", ".sbv", ".idx", ".smi", ".ttml", ".dfxp"
+    };
+
+    /// <summary>
+    /// What alass reads. Its own README lists srt, ass, ssa, idx and sub, but the plugin
+    /// only claims the plain text ones here: an engine that turns out to read more says so
+    /// through --formats, and claiming too much would mean handing it a file it fails on.
+    /// </summary>
+    public static readonly string[] Alass = { ".srt", ".ass", ".ssa", ".vtt" };
+
+    /// <summary>
+    /// What ffsubsync reads.
+    /// </summary>
+    public static readonly string[] Ffsubsync = { ".srt", ".ass", ".ssa", ".vtt" };
+
+    /// <summary>
+    /// Gets the formats an engine reads, without asking its binary.
+    /// </summary>
+    /// <param name="engineId">The engine id.</param>
+    /// <returns>The extensions, each with a leading dot.</returns>
+    public static IReadOnlyList<string> ForEngine(string? engineId)
+    {
+        return (engineId ?? string.Empty).ToLowerInvariant() switch
+        {
+            "lapse" => Lapse,
+            "alass" => Alass,
+            "ffsubsync" => Ffsubsync,
+
+            // An engine the plugin doesn't know gets the set every one of them has always
+            // taken, which is the safe answer rather than the generous one.
+            _ => Ffsubsync
+        };
+    }
+
+    /// <summary>
+    /// Says whether an engine reads a file as it stands, going by the static list rather
+    /// than by what the installed binary reports. Used where there's no binary to ask -
+    /// listing an item's subtitles, mostly - while the runner uses the probed answer.
+    /// </summary>
+    /// <param name="engineId">The engine id.</param>
+    /// <param name="path">The subtitle path.</param>
+    /// <returns>True if that engine takes the file directly.</returns>
+    public static bool CanRead(string? engineId, string? path)
+    {
+        return Contains(ForEngine(engineId), path);
+    }
+
+    /// <summary>
+    /// Says whether the engine a plain Sync press would use reads a file as it stands.
+    /// </summary>
+    /// <param name="path">The subtitle path.</param>
+    /// <returns>True if the default engine takes the file directly.</returns>
+    public static bool DefaultEngineCanRead(string? path)
+    {
+        return CanRead(Plugin.Instance?.Configuration.DefaultEngineId, path);
+    }
+
+    /// <summary>
+    /// Checks a path against a list of extensions.
+    /// </summary>
+    /// <param name="extensions">The extensions to match, each with a leading dot.</param>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True if the path's extension is on the list.</returns>
+    public static bool Contains(IReadOnlyList<string> extensions, string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(path);
+        if (extension.Length == 0)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < extensions.Count; i++)
+        {
+            if (string.Equals(extensions[i], extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Turns a list of extensions into something to show a person: ".srt, .ass, .vtt".
+    /// </summary>
+    /// <param name="extensions">The extensions.</param>
+    /// <returns>A comma separated list.</returns>
+    public static string Describe(IReadOnlyList<string> extensions)
+    {
+        return string.Join(", ", extensions);
+    }
+}

--- a/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
@@ -213,6 +213,17 @@ public class EngineRunner
     }
 
     /// <summary>
+    /// Gets the format conversions produce, falling back to srt when what's configured
+    /// isn't a format the converter writes.
+    /// </summary>
+    /// <returns>The format name, without a dot.</returns>
+    public static string ResolveConversionFormat()
+    {
+        var configured = Plugin.Instance?.Configuration.ConversionFormat;
+        return SubtitleFormats.TryNormalizeOutputFormat(configured, out var format) ? format : "srt";
+    }
+
+    /// <summary>
     /// Gets the output mode a run should use, preferring what the caller asked for over
     /// what's configured.
     /// </summary>
@@ -327,15 +338,25 @@ public class EngineRunner
 
         var runtime = await _probe.ProbeAsync(enginePath, cancellationToken).ConfigureAwait(false);
 
-        // The engines only read srt, vtt, ass and ssa. Anything else text based - MicroDVD
-        // and the like - gets turned into srt first and the sync runs on that, since the
-        // alternative is turning the item away for a format the plugin can perfectly well
-        // read. The result then has to come out as srt too: there's no writing a MicroDVD
-        // file back, and quietly leaving the old one in place would be worse.
+        // Engines differ in what they read, so the question is asked of this engine rather
+        // than assumed: LAPSE 2.0.3 takes eleven formats, including PGS and VobSub, and
+        // writes each one back as itself, where alass and ffsubsync take four. Anything an
+        // engine can't read gets converted first, because turning the item away for a
+        // format the plugin can perfectly well read would be worse. On top of that, an
+        // admin can ask for everything to be converted before syncing, which is the only
+        // way to end up with one format across a library that has several.
         string? convertedInput = null;
         var enginePathIn = subtitlePath;
 
-        if (!SubtitleFormats.IsNative(subtitlePath))
+        var engineReads = runtime.CanRead(engine.Descriptor.Id, subtitlePath);
+        var conversionFormat = ResolveConversionFormat();
+
+        // Nothing to do when the file is already in the format that would be asked for.
+        var convertAnyway = Plugin.Instance?.Configuration.ConvertBeforeSync == true
+            && SubtitleFormats.IsTextBased(subtitlePath)
+            && !string.Equals(SubtitleFormats.GetName(subtitlePath), conversionFormat, StringComparison.OrdinalIgnoreCase);
+
+        if (!engineReads || convertAnyway)
         {
             if (_converter.GetConversionProblem(subtitlePath) is { } conversionProblem)
             {
@@ -348,7 +369,11 @@ public class EngineRunner
                 };
             }
 
-            convertedInput = subtitlePath + ".lapse-converted.srt";
+            // A conversion the engine didn't ask for is the admin's choice of format; one
+            // it did ask for goes to srt, which every engine reads.
+            var convertTo = engineReads ? conversionFormat : "srt";
+
+            convertedInput = subtitlePath + ".lapse-converted." + convertTo;
 
             try
             {
@@ -367,7 +392,11 @@ public class EngineRunner
             }
 
             enginePathIn = convertedInput;
-            outputFormat ??= "srt";
+
+            // The result has to come out in the converted format: there's no writing a
+            // MicroDVD file back from srt cues, and quietly leaving the old file in place
+            // would be worse than adding a new one beside it.
+            outputFormat ??= convertTo;
         }
 
         var resolvedOutputMode = ResolveOutputMode(outputMode);
@@ -481,6 +510,8 @@ public class EngineRunner
                 File.Move(workPath, destination, overwrite: true);
             }
 
+            CopyVobSubCompanion(subtitlePath, destination);
+
             result.OutputPath = destination;
             result.InputPath = subtitlePath;
             result.ConvertedFrom = convertedInput is null ? null : SubtitleFormats.GetName(subtitlePath);
@@ -509,6 +540,43 @@ public class EngineRunner
             {
                 CleanUp(convertedInput);
             }
+        }
+    }
+
+    // A VobSub subtitle is two files: the .idx holds the timings, the .sub beside it holds
+    // the pictures, and a player only finds the pictures by looking for a .sub named after
+    // the .idx. Syncing one to a sidecar therefore writes a .idx that points at nothing,
+    // so the pictures get copied over under the new name too. Overwriting in place needs
+    // none of this, since the .sub it already had is still the right one.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Security",
+        "CA3003:Review code for file path injection vulnerabilities",
+        Justification = "Both paths are derived from a subtitle path the caller already validated.")]
+    private void CopyVobSubCompanion(string subtitlePath, string destination)
+    {
+        if (!string.Equals(Path.GetExtension(subtitlePath), ".idx", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(subtitlePath, destination, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var source = Path.ChangeExtension(subtitlePath, ".sub");
+        var target = Path.ChangeExtension(destination, ".sub");
+
+        if (!File.Exists(source) || string.Equals(source, target, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Copy(source, target, overwrite: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The synced .idx is written either way; without its pictures it just won't
+            // show anything, which is worth a line in the log rather than failing the run.
+            _logger.LogWarning(ex, "Synced {Idx} but could not copy its .sub pictures to {Target}", subtitlePath, target);
         }
     }
 

--- a/Jellyfin.Plugin.Lapse/Engines/EngineRuntimeInfo.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineRuntimeInfo.cs
@@ -34,6 +34,13 @@ public class EngineRuntimeInfo
     public List<string> Flags { get; } = new();
 
     /// <summary>
+    /// Gets the subtitle extensions the binary said it reads, from its <c>--formats</c>
+    /// call. Empty when the binary has no such call, in which case the caller falls back
+    /// to <see cref="EngineFormats.ForEngine"/>.
+    /// </summary>
+    public List<string> ReportedExtensions { get; } = new();
+
+    /// <summary>
     /// Gets or sets a value indicating whether the probe actually got an answer. False
     /// means everything else here is the conservative default rather than measured.
     /// </summary>
@@ -71,6 +78,29 @@ public class EngineRuntimeInfo
     /// </summary>
     public bool SupportsAutoMode =>
         UsageText is not null && UsageText.Contains("auto|", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the subtitle formats this engine reads: what the binary reported if it
+    /// reported anything, otherwise the list the plugin knows the project by.
+    /// </summary>
+    /// <param name="engineId">The engine id, for the fallback list.</param>
+    /// <returns>The extensions, each with a leading dot.</returns>
+    public IReadOnlyList<string> GetSubtitleExtensions(string engineId)
+    {
+        return ReportedExtensions.Count > 0 ? ReportedExtensions : EngineFormats.ForEngine(engineId);
+    }
+
+    /// <summary>
+    /// Says whether this binary reads a subtitle file as it stands, so it can be handed
+    /// over without being converted first.
+    /// </summary>
+    /// <param name="engineId">The engine id, for the fallback list.</param>
+    /// <param name="path">The subtitle path.</param>
+    /// <returns>True if the engine takes the file directly.</returns>
+    public bool CanRead(string engineId, string? path)
+    {
+        return EngineFormats.Contains(GetSubtitleExtensions(engineId), path);
+    }
 
     /// <summary>
     /// Checks whether the binary said it understands a flag.

--- a/Jellyfin.Plugin.Lapse/Engines/FfsubsyncEngine.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/FfsubsyncEngine.cs
@@ -153,7 +153,8 @@ public partial class FfsubsyncEngine : IEngine
                 SupportsPenalty = true,
                 DefaultPenalty = 7,
                 MinPenalty = 0,
-                MaxPenalty = 100
+                MaxPenalty = 100,
+                SubtitleExtensions = EngineFormats.Ffsubsync
             }
         };
 

--- a/Jellyfin.Plugin.Lapse/Engines/LapseEngine.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/LapseEngine.cs
@@ -198,6 +198,11 @@ public partial class LapseEngine : IEngine
                 + "The other two engines take encoding arguments because they do not do this.",
             WhyUrl = BenchmarksUrl,
             WhyLabel = "Why is this recommended? Read more on GitHub",
+            DeploymentNote = "LAPSE also ships as a Docker image with a file watcher in it. Point it at "
+                + "the folders you want it to look after and it syncs new files on its own, with no Jellyfin "
+                + "involved. There is a web UI too, for anyone who would rather manage it from a browser than "
+                + "the command line. Useful if you want subtitles fixed before Jellyfin ever sees them, or if "
+                + "you keep media that isn't in a Jellyfin library. Setup and settings are in the repo.",
             LinuxAmd64 = Archive("lapse-linux-amd64.tar.gz", EnginePackaging.TarGz),
             LinuxArm64 = Archive("lapse-linux-arm64.tar.gz", EnginePackaging.TarGz),
             MacAmd64 = Archive("lapse-macos-x86_64.tar.gz", EnginePackaging.TarGz),
@@ -212,7 +217,8 @@ public partial class LapseEngine : IEngine
                 SupportsPenalty = true,
                 DefaultPenalty = 6,
                 MinPenalty = 0,
-                MaxPenalty = 100
+                MaxPenalty = 100,
+                SubtitleExtensions = EngineFormats.Lapse
             }
         };
 

--- a/Jellyfin.Plugin.Lapse/Services/AutoSyncHostedService.cs
+++ b/Jellyfin.Plugin.Lapse/Services/AutoSyncHostedService.cs
@@ -18,6 +18,10 @@ namespace Jellyfin.Plugin.Lapse.Services;
 /// same as the classic intro-skipper auto-detect hook. Debounced with a timer so a big
 /// library scan that adds a bunch of items at once doesn't kick off a sync per item
 /// the instant each one shows up, before its subtitles have even settled.
+///
+/// This is what means adding a film doesn't have to wait for the next scheduled run. It
+/// is per library, so a library can be on for scheduled and bulk runs and still not have
+/// every new file picked up the moment it lands.
 /// </summary>
 public sealed class AutoSyncHostedService : IHostedService, IDisposable
 {
@@ -108,9 +112,11 @@ public sealed class AutoSyncHostedService : IHostedService, IDisposable
                 continue;
             }
 
-            if (!_libraryService.IsEligible(item))
+            if (!_libraryService.IsAutoSyncEnabled(item))
             {
-                _logger.LogDebug("Auto-sync skipping {Item}, its library is turned off or it's on the skip list", item.Name);
+                _logger.LogDebug(
+                    "Auto-sync skipping {Item}: its library is turned off, has auto-sync turned off, or it's on the skip list",
+                    item.Name);
                 continue;
             }
 

--- a/Jellyfin.Plugin.Lapse/Services/LibraryService.cs
+++ b/Jellyfin.Plugin.Lapse/Services/LibraryService.cs
@@ -71,6 +71,7 @@ public class LibraryService
                 // no entry means the user has never touched this library in the dashboard,
                 // and those default to on so an upgrade doesn't quietly stop syncing
                 Enabled = settings?.Enabled ?? true,
+                AutoSyncEnabled = settings?.AutoSyncEnabled ?? true,
                 ScheduleEnabled = settings?.ScheduleEnabled ?? false,
                 ScheduleFrequency = (settings?.ScheduleFrequency ?? Data.ScheduleFrequency.Daily).ToString(),
                 ScheduleDay = settings?.ScheduleDay?.ToString(),
@@ -182,6 +183,33 @@ public class LibraryService
         // an item we can't place in a library (a stray item, or a library the plugin
         // can't see) is left alone rather than synced on a guess
         return libraryId.HasValue && Plugin.Instance!.Configuration.IsLibraryEnabled(libraryId.Value);
+    }
+
+    /// <summary>
+    /// Says whether a newly added item should be picked up straight away. Eligibility on
+    /// its own isn't enough: a library can be turned on for scheduled and bulk runs while
+    /// still not wanting every new file grabbed the moment it lands.
+    /// </summary>
+    /// <param name="item">The item that was just added.</param>
+    /// <returns>True if auto-sync should queue it.</returns>
+    public bool IsAutoSyncEnabled(BaseItem item)
+    {
+        if (!IsEligible(item))
+        {
+            return false;
+        }
+
+        var libraryId = GetLibraryIdFor(item);
+        if (!libraryId.HasValue)
+        {
+            return false;
+        }
+
+        var settings = Plugin.Instance!.Configuration.Libraries
+            .FirstOrDefault(l => l.LibraryId == libraryId.Value);
+
+        // A library nobody has configured counts as on, same as everywhere else here
+        return settings?.AutoSyncEnabled ?? true;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Lapse/Services/SubtitleFormats.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SubtitleFormats.cs
@@ -26,15 +26,18 @@ public enum SubtitleFormatKind
     Native = 1,
 
     /// <summary>
-    /// A text based format the engines don't take, but ffmpeg can turn into srt first -
-    /// MicroDVD, SAMI, SubViewer, TTML and friends.
+    /// A text based format the plugin doesn't parse itself, but ffmpeg can turn into srt
+    /// first - MicroDVD, SAMI, SubViewer, TTML and friends. Whether an engine needs that
+    /// done is a separate question, and one only the engine can answer: LAPSE reads most
+    /// of these directly. See <see cref="Engines.EngineFormats"/>.
     /// </summary>
     Convertible = 2,
 
     /// <summary>
     /// A picture based format - PGS, VobSub, DVD subs. There's no text in these at all,
-    /// only bitmaps, so nothing short of OCR gets them into a shape anything here can
-    /// use.
+    /// only bitmaps, so nothing here can convert, translate or shift one. Syncing is a
+    /// different matter: LAPSE rewrites the timing without touching the pictures, so an
+    /// engine that says it reads them can line one up.
     /// </summary>
     ImageBased = 3
 }
@@ -43,6 +46,11 @@ public enum SubtitleFormatKind
 /// The subtitle formats the plugin knows about, and which of them each part of it can
 /// work on. Everything that asks "can I do this to that file" comes through here, so
 /// there's one answer rather than a list of extensions repeated in five places.
+///
+/// This is about what the <em>plugin</em> can do: read the text out, write it back,
+/// translate it, shift it by hand. What an <em>engine</em> can do is asked of the engine,
+/// in <see cref="Engines.EngineFormats"/>, because the answer differs per engine and per
+/// installed build.
 /// </summary>
 public static class SubtitleFormats
 {
@@ -134,6 +142,18 @@ public static class SubtitleFormats
     public static bool IsSubtitle(string? path)
     {
         return GetKind(path) != SubtitleFormatKind.Unknown;
+    }
+
+    /// <summary>
+    /// Gets whether a path holds text the plugin can get at, one way or another. This is
+    /// what converting, translating and shifting by hand all need, and it's the line the
+    /// picture based formats fall on the wrong side of.
+    /// </summary>
+    /// <param name="path">The file path.</param>
+    /// <returns>True for the native and convertible formats.</returns>
+    public static bool IsTextBased(string? path)
+    {
+        return GetKind(path) is SubtitleFormatKind.Native or SubtitleFormatKind.Convertible;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Lapse/Services/SubtitleLocator.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SubtitleLocator.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Jellyfin.Plugin.Lapse.Data;
+using Jellyfin.Plugin.Lapse.Engines;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 
@@ -246,14 +247,26 @@ public class SubtitleLocator
     {
         var kind = SubtitleFormats.GetKind(path);
 
+        // Whether a file needs converting is the default engine's business, not the
+        // plugin's: LAPSE reads MicroDVD, SAMI, TTML, PGS and VobSub as they are, so
+        // saying "this has to be converted first" about one of those would be wrong and
+        // would cost the user a pointless extra file. The static list is used rather than
+        // the binary's own --formats answer because this runs once per subtitle while a
+        // page loads, and starting a process for each of them isn't worth the precision.
+        var engineReads = EngineFormats.DefaultEngineCanRead(path);
+
         return new SubtitleOption
         {
             Path = path,
             DisplayName = displayName,
             Language = language,
             Format = SubtitleFormats.GetName(path),
-            NeedsConversion = kind == SubtitleFormatKind.Convertible,
-            Supported = kind != SubtitleFormatKind.ImageBased
+            NeedsConversion = kind == SubtitleFormatKind.Convertible && !engineReads,
+            TextBased = kind != SubtitleFormatKind.ImageBased,
+
+            // A picture based subtitle is only worth offering when the engine can line it
+            // up, since there's nothing else here that can be done to one.
+            Supported = kind != SubtitleFormatKind.ImageBased || engineReads
         };
     }
 

--- a/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,9 +20,13 @@ namespace Jellyfin.Plugin.Lapse.Services;
 /// <summary>
 /// Runs bulk (and auto-sync) subtitle sync jobs one item at a time in the background,
 /// so the dashboard doesn't have to wait around for a whole library to finish.
-/// Bulk and auto-sync jobs always run standard mode with the default engine against every
+/// Bulk and auto-sync jobs always run the default engine's default mode against every
 /// external subtitle an item has - there's no UI in the background path to pick
 /// engine/mode/penalty/subtitle.
+///
+/// What it does to each of those subtitles is the Automation setting's business: sync
+/// them, convert them, or both, and optionally translate the result. See
+/// <see cref="AutomationAction"/>.
 /// </summary>
 public class SyncQueueManager : IDisposable
 {
@@ -30,6 +35,8 @@ public class SyncQueueManager : IDisposable
     private readonly SubtitleLocator _subtitleLocator;
     private readonly EngineRegistry _registry;
     private readonly EngineRunner _runner;
+    private readonly SubtitleConverter _converter;
+    private readonly Translation.TranslationService _translationService;
     private readonly ILogger<SyncQueueManager> _logger;
     private readonly object _lock = new();
     private readonly List<QueueItem> _items = new();
@@ -56,6 +63,10 @@ public class SyncQueueManager : IDisposable
     /// <param name="subtitleLocator">Finds every subtitle for an item.</param>
     /// <param name="registry">Used to pick the configured default engine.</param>
     /// <param name="runner">Runs the engine.</param>
+    /// <param name="converter">Changes a subtitle's format, for the automation actions
+    /// that ask for it.</param>
+    /// <param name="translationService">Translates subtitles, when automatic translation
+    /// is turned on.</param>
     /// <param name="logger">Logger.</param>
     public SyncQueueManager(
         ILibraryManager libraryManager,
@@ -63,6 +74,8 @@ public class SyncQueueManager : IDisposable
         SubtitleLocator subtitleLocator,
         EngineRegistry registry,
         EngineRunner runner,
+        SubtitleConverter converter,
+        Translation.TranslationService translationService,
         ILogger<SyncQueueManager> logger)
     {
         _libraryManager = libraryManager;
@@ -70,6 +83,8 @@ public class SyncQueueManager : IDisposable
         _subtitleLocator = subtitleLocator;
         _registry = registry;
         _runner = runner;
+        _converter = converter;
+        _translationService = translationService;
         _logger = logger;
     }
 
@@ -476,6 +491,9 @@ public class SyncQueueManager : IDisposable
             }
         }
 
+        var action = Plugin.Instance?.Configuration.AutomationAction ?? AutomationAction.Sync;
+        var converted = 0;
+
         foreach (var subtitle in subtitles)
         {
             if (reference is not null && string.Equals(subtitle.Path, reference.Path, StringComparison.Ordinal))
@@ -484,17 +502,49 @@ public class SyncQueueManager : IDisposable
                 continue;
             }
 
+            var workPath = subtitle.Path;
+
+            // Converting first is a deliberate choice now rather than a necessity. The
+            // engine reads what it reads either way, and the runner converts on its own
+            // when it has to; this is the admin saying they want one format on disk.
+            if (action is AutomationAction.Convert or AutomationAction.ConvertThenSync)
+            {
+                var (convertedPath, convertError, didWrite) = await ConvertForAutomationAsync(subtitle, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (convertError is not null)
+                {
+                    lastError = convertError;
+                    _logger.LogWarning("Converting {Subtitle} for {Item} failed: {Error}", subtitle.Path, item.Name, convertError);
+                    continue;
+                }
+
+                workPath = convertedPath;
+                if (didWrite)
+                {
+                    converted++;
+                }
+            }
+
+            if (action == AutomationAction.Convert)
+            {
+                // The whole job for this file was the conversion. Syncing is somebody
+                // else's press, or another run with a different action set.
+                await TranslateForAutomationAsync(item, workPath, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
             var referencePath = reference?.Path ?? item.Path;
 
             var result = await _runner
-                .RunAsync(engine, referencePath, subtitle.Path, mode, penalty, outputMode: null, destinationOverride: null, outputFormat: null, cancellationToken)
+                .RunAsync(engine, referencePath, workPath, mode, penalty, outputMode: null, destinationOverride: null, outputFormat: null, cancellationToken)
                 .ConfigureAwait(false);
             lastResult = result;
 
             if (!result.Success)
             {
                 lastError = result.Error;
-                _logger.LogWarning("Sync failed for {Item} ({Subtitle}): {Error}", item.Name, subtitle.Path, result.Error);
+                _logger.LogWarning("Sync failed for {Item} ({Subtitle}): {Error}", item.Name, workPath, result.Error);
             }
             else if (result.Skipped)
             {
@@ -505,7 +555,11 @@ public class SyncQueueManager : IDisposable
                 // Only a subtitle we actually rewrote counts. A failure and a deliberate
                 // low-confidence skip both leave the file as it was, so neither of them
                 // should make the item look any more synced than it was before.
-                syncedPaths.Add(subtitle.Path);
+                syncedPaths.Add(workPath);
+
+                // Translate what the sync produced rather than what it read, so the
+                // translation carries the corrected timings.
+                await TranslateForAutomationAsync(item, result.OutputPath ?? workPath, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -514,6 +568,19 @@ public class SyncQueueManager : IDisposable
             SaveRecord(itemId, MovieSyncStatus.Failed, lastError, lastResult, syncedPaths);
             SetItemStatus(itemId, QueueItemStatus.Failed);
             return false;
+        }
+
+        if (action == AutomationAction.Convert)
+        {
+            // Nothing here was synced, and saying otherwise would misreport what's on
+            // disk. The item stays where it was with a line explaining why.
+            var detail = converted == 0
+                ? "Everything here was already in the conversion format, and the automation action is set to convert only, so nothing was synced."
+                : $"Converted {converted} subtitle{(converted == 1 ? string.Empty : "s")}. The automation action is set to convert only, so nothing was synced.";
+
+            SaveRecord(itemId, MovieSyncStatus.Pending, detail);
+            SetItemStatus(itemId, QueueItemStatus.Done);
+            return true;
         }
 
         if (lastSkip is not null)
@@ -529,6 +596,112 @@ public class SyncQueueManager : IDisposable
         SaveRecord(itemId, MovieSyncStatus.Synced, null, lastResult, syncedPaths);
         SetItemStatus(itemId, QueueItemStatus.Done);
         return true;
+    }
+
+    // Writes the subtitle out in the configured conversion format. Returns the path to
+    // carry on with, an error, and whether a new file was actually written.
+    private async Task<(string Path, string? Error, bool Written)> ConvertForAutomationAsync(
+        SubtitleOption subtitle,
+        CancellationToken cancellationToken)
+    {
+        var format = EngineRunner.ResolveConversionFormat();
+
+        if (string.Equals(subtitle.Format, format, StringComparison.OrdinalIgnoreCase))
+        {
+            return (subtitle.Path, null, false);
+        }
+
+        // A picture based subtitle has no text to convert. That isn't a failure of the
+        // run, it just can't take part in this half of it.
+        if (_converter.GetConversionProblem(subtitle.Path) is not null)
+        {
+            return (subtitle.Path, null, false);
+        }
+
+        var destination = System.IO.Path.ChangeExtension(subtitle.Path, "." + format);
+
+        // Already converted on an earlier run, so don't pay for it again
+        if (File.Exists(destination))
+        {
+            return (destination, null, false);
+        }
+
+        try
+        {
+            await _converter.ConvertAsync(subtitle.Path, destination, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is NotSupportedException or InvalidDataException or IOException or TimeoutException)
+        {
+            return (subtitle.Path, "Could not convert " + System.IO.Path.GetFileName(subtitle.Path) + ": " + ex.Message, false);
+        }
+
+        if (Plugin.Instance?.Configuration.ConversionReplaceOriginal == true)
+        {
+            TryDelete(subtitle.Path);
+        }
+
+        return (destination, null, true);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // the converted file is written either way
+        }
+    }
+
+    // Experimental. Off unless someone turned it on and named a language.
+    private async Task TranslateForAutomationAsync(BaseItem item, string subtitlePath, CancellationToken cancellationToken)
+    {
+        var config = Plugin.Instance?.Configuration;
+        var language = config?.AutoTranslateLanguage?.Trim();
+
+        if (config?.AutoTranslateEnabled != true || string.IsNullOrEmpty(language))
+        {
+            return;
+        }
+
+        if (!SubtitleFormats.IsTextBased(subtitlePath) || !File.Exists(subtitlePath))
+        {
+            return;
+        }
+
+        var destination = SubtitleTextFile.BuildOutputPath(subtitlePath, language);
+
+        if (config.AutoTranslateSkipExisting && File.Exists(destination))
+        {
+            return;
+        }
+
+        var request = new TranslationRequest
+        {
+            ItemId = item.Id,
+            SubtitlePath = subtitlePath,
+            TargetLanguage = language
+        };
+
+        var result = await _translationService.TranslateAsync(subtitlePath, request, cancellationToken).ConfigureAwait(false);
+
+        if (result.Success)
+        {
+            _logger.LogInformation(
+                "Auto-translated {Subtitle} into {Language} ({Low} of {Total} lines below the threshold)",
+                subtitlePath,
+                language,
+                result.LowConfidenceCount,
+                result.LineCount);
+        }
+        else
+        {
+            // A translation that failed leaves the synced subtitle untouched, so this is
+            // logged rather than being allowed to fail the item.
+            _logger.LogWarning("Auto-translating {Subtitle} into {Language} failed: {Error}", subtitlePath, language, result.Error);
+        }
     }
 
     private void SetItemStatus(Guid itemId, QueueItemStatus status)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,23 @@ Every film, episode and loose video gets two new entries in its three dot menu.
 
 **Sync Subtitles** is the one you will use. Press it, press Sync, wait. If the item has several subtitles it asks which one. There is an Advanced button in there too if you want to pick a different mode, a different output format, translate the subtitle, or nudge the timing by hand.
 
-Subtitles that came inside the video file count. Most films only ever have those, and an engine cannot read a track that only exists inside an mkv, so the first time you sync one the plugin copies it out to a file next to the video and works on that. It is a one off: from then on it is an ordinary subtitle file, and Jellyfin picks it up as another track on its next scan. Picture based tracks (PGS, VobSub) are listed but cannot be synced, because they are images of text rather than text.
+Subtitles that came inside the video file count. Most films only ever have those, and an engine cannot read a track that only exists inside an mkv, so the first time you sync one the plugin copies it out to a file next to the video and works on that. It is a one off: from then on it is an ordinary subtitle file, and Jellyfin picks it up as another track on its next scan.
+
+### Which subtitle formats work
+
+LAPSE 2.0.3 reads and writes `.srt`, `.ass`, `.ssa`, `.vtt`, `.sub` (MicroDVD), `.sup` (PGS), `.sbv`, `.idx` (VobSub, point it at the `.idx`), `.smi`, `.ttml` and `.dfxp`, and writes each one back in the format it read. So a MicroDVD file stays MicroDVD and a PGS file stays PGS. PGS and VobSub are bitmaps with no text in them, but their timing is still timing, so LAPSE moves that without touching the pictures. Syncing a `.idx` to a new file copies its `.sub` of pictures across too, since a VobSub subtitle is only complete with both.
+
+The plugin asks the installed binary which formats it takes (`lapse --formats`), so this stays right if you are on an older or newer build than the one above. alass and ffsubsync take `.srt`, `.ass`, `.ssa` and `.vtt`; anything else gets converted to `.srt` first when one of those is the engine in use.
+
+There is no text in a picture based subtitle, so converting, translating and hand shifting still cannot touch one. Those need OCR first, with something like Subtitle Edit.
 
 **Sync All Subtitles to Reference** is for items with several subtitle tracks where one of them is already correct. Pick that one and everything else on the item gets lined up against it. Matching a subtitle against another subtitle skips the audio entirely, so it takes a second or two instead of a minute, and it is usually more accurate than syncing each track separately.
 
 There is also a **Shift Subtitles** entry for when a sync gets close but is still a hair off. It shows you a real line from the file, a slider, and a millisecond box, and the preview updates as you drag. It does not touch the engine, so it works even before you have installed one. Works on `.srt`, `.vtt`, `.ass` and `.ssa`.
 
-**Convert Subtitles** writes one of the item's subtitles out as `.srt`, `.vtt`, `.ass` or `.ssa`. The original stays where it is unless you tell it to delete it. Useful on its own when a player only takes one format, and it is also how you get a hand-editable `.srt` or `.vtt` out of an `.ass`/`.ssa` file before shifting it. The Advanced sync dialog has the same choice built in as "Write the result as", along with a file output mode for that one run and a tick box for translating as well, so one press can convert, sync and translate in that order. Subtitles in a text format no engine reads, MicroDVD, SAMI, SubViewer and a few others, get converted automatically the first time you sync one: the plugin turns it into `.srt` behind the scenes and syncs that. Picture-based subtitles (PGS, VobSub) hold no text at all, so there is nothing here to convert. Those need OCR first, with something like Subtitle Edit.
+**Convert Subtitles** writes one of the item's subtitles out as `.srt`, `.vtt`, `.ass` or `.ssa`. The original stays where it is unless you tell it to delete it. Useful on its own when a player only takes one format, and it is also how you get a hand-editable `.srt` or `.vtt` out of an `.ass`/`.ssa` file before shifting it. The Advanced sync dialog has the same choice built in as "Write the result as", along with a file output mode for that one run and a tick box for translating as well, so one press can convert, sync and translate in that order.
+
+Converting is optional with LAPSE. It reads eleven formats and writes each one back as itself, so there is nothing it needs converting into first, and leaving a file in the format it arrived in means one file on disk instead of two. The plugin converts on its own only when the engine in use cannot read the format, which with alass and ffsubsync means anything outside `.srt`, `.ass`, `.ssa` and `.vtt`. If you would rather have `.srt` everywhere regardless, Settings > Conversion has an "always convert first" option. Picture-based subtitles (PGS, VobSub) hold no text at all, so there is nothing here to convert, whatever the engine can do with their timing.
 
 Who besides you can use any of this on an item they can already see is controlled from Settings > Access, described below.
 
@@ -48,13 +58,15 @@ What is behind that Settings group:
 
 **Engines** is where you install, update and switch engines, and where each engine's Advanced section lives. More on that below.
 
-**Libraries** has an on/off switch per library and an optional schedule with a day and a time. A library you have never touched counts as on, so an update never quietly stops syncing something.
+**Libraries** has an on/off switch per library, a **New items** switch, and an optional schedule with a day and a time. New items is the one that means adding a film does not have to wait for the schedule: anything that turns up in that library gets picked up on its own about half a minute later, once its files have settled. Both switches are per library, so a library can be on a weekly schedule without every new file being grabbed the moment it lands, or the other way round. A library you have never touched counts as on with new items on, so an update never quietly stops syncing something.
+
+**Automation** decides what those unattended runs actually do: sync the subtitles, convert them, or convert and then sync. It covers the scheduled task, the per-library schedules, new items, bulk runs and the Radarr/Sonarr webhook. Pressing Sync or Convert on one item yourself is not affected by it. There is also an experimental automatic translation switch here, described further down.
 
 **Access** decides who besides you can sync, shift, convert and translate. Admin only by default.
 
 **File output** decides what happens to the file you synced. This is the setting worth reading before you run a bulk sync. It is about synced files only; converted ones have their own page.
 
-**Conversion** is where format changing lives: which format to convert to (srt by default, since everything reads it), whether the file it read is kept or deleted (kept by default, so there is always something to go back to), and whether a subtitle that had to be converted before an engine could read it then gets synced automatically (it does by default).
+**Conversion** is where format changing lives: which format to convert to (srt by default, since everything reads it), whether the file it read is kept or deleted (kept by default, so there is always something to go back to), whether every subtitle gets converted before syncing or only the ones the engine cannot read (only those, by default), and whether a subtitle that had to be converted then gets synced automatically (it does by default). The page tells you which formats the engine you are actually using reads, so you can see for yourself whether converting buys you anything.
 
 **Ignore list** is for things you never want touched automatically. Ignoring a series or a folder covers everything inside it, and ignored items show up greyed out and struck through in the status list so you can see at a glance what is being left alone. You can still sync an ignored item by hand.
 
@@ -79,7 +91,9 @@ The item menu entries (Sync, Shift, Convert, Translate) are admin only until you
 
 ## Engines
 
-**LAPSE** is the one this plugin is built around and the one to use. It listens to the audio and works out on its own whether the subtitle is simply early, drifting because it was made for a different framerate, split across a re-cut, or some combination, then fixes whichever it is. It also says how sure it is about the answer, which none of the others do. Builds are published for Linux, macOS and Windows, so it runs wherever Jellyfin does.
+**LAPSE** is the one this plugin is built around and the one to use. It listens to the audio and works out on its own whether the subtitle is simply early, drifting because it was made for a different framerate, split across a re-cut, or some combination, then fixes whichever it is. It also says how sure it is about the answer, which none of the others do, and it reads far more subtitle formats than the other two. Builds are published for Linux, macOS and Windows, so it runs wherever Jellyfin does.
+
+LAPSE also ships as a Docker image with a file watcher in it. Point it at the folders you want looked after and it syncs new files on its own, no Jellyfin involved, which is useful if you want subtitles fixed before Jellyfin ever sees them or if you keep media outside a Jellyfin library. A file is left alone until it stops changing, so a download still being written is not touched. There is a web UI too, for anyone who would rather manage it from a browser than the command line. Setup and settings are in the [engine repo](https://github.com/Schwponaco-org/lapse).
 
 **alass** splits the file into sections and times each one separately. Handy for recordings cut around ad breaks. Only x86_64 builds are published, for Linux and Windows.
 
@@ -148,9 +162,19 @@ Providers are MyMemory (works with no setup), self-hosted LibreTranslate and Lin
 
 Neither provider reports a confidence number, so rather than pretending otherwise the plugin scores each line on what it can see: whether anything came back, whether the text changed, whether the length is plausible, and whether the detected language matches what was asked for. Lines below the threshold are counted and optionally left in their original language.
 
+### Translating automatically (experimental)
+
+Settings > Automation has a switch that puts every subtitle an unattended run touches through a translation provider, into a language you name. It is off by default and worth thinking about before turning on.
+
+A library is a great deal of text. Every subtitle is a few hundred to a few thousand lines, and this sends all of them, for every item in every enabled library, on every run. Check what your provider allows and what it charges before you point this at a real library, and start with one small library to see what it costs you. MyMemory in particular rate limits hard once you go past casual use.
+
+Machine translation also gets things wrong without telling you it has. That is why translations are written to a new file and never replace the one they were made from, and why it is worth keeping File output on one of the backup modes and keeping your originals. Read a couple of the results before trusting the rest.
+
+"Skip subtitles that already have a translation in that language" is on by default and should stay on. Without it, every scheduled run translates the whole library again from scratch and pays for it again.
+
 ## Experimental
 
-Two features live behind an Experimental page because they depend on things outside Jellyfin and can break when those things change.
+Two more features live behind an Experimental page because they depend on things outside Jellyfin and can break when those things change.
 
 **Fetching from OpenSubtitles.** If you press Sync on an item that has no subtitle at all, the plugin can go and get one first, then sync it. Items that already have a subtitle are untouched. You need an API key from opensubtitles.com, and an account name and password on top of that, because their API hands out search results to a key alone but a download needs a login token. Downloads come out of that account's daily quota.
 
@@ -163,6 +187,8 @@ The URL carries a secret, which is the only thing protecting it, because neither
 ## Scheduled tasks
 
 Two show up under Dashboard > Scheduled Tasks. *Sync subtitles* runs over every enabled library. *Update sync engines* checks GitHub for newer engine releases once a day.
+
+What *Sync subtitles* does to each subtitle it finds comes from Settings > Automation, same as the per-library schedules and the new-item pickup. Per-library schedules are not in this list, because a Jellyfin trigger belongs to a task rather than to a library; they are set up on the Libraries page and run on a one minute tick of their own.
 
 ## License
 


### PR DESCRIPTION
…d automation controls

LAPSE 2.0.3 reads and writes eleven subtitle formats instead of four, including PGS and VobSub, so converting before syncing is no longer required in most cases. The plugin now asks each installed engine (via --formats) what it actually supports and only converts when the engine can't read the format, with a setting to force conversion anyway.

Also adds:
- an Automation page controlling what unattended runs (scheduled task, per-library schedules, new items, bulk, webhook) do: sync, convert, or both, plus an experimental auto-translate option
- a per-library "New items" toggle, separate from the schedule toggle
- a note on the LAPSE engine card about running it via Docker with its file watcher and web UI