### PR TITLE
Add sync job cancellation, single-track reference sync, and translati…

### DIFF
--- a/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
@@ -99,6 +99,19 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AutoUpdateEngines { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether tracks still inside the video file count
+    /// towards an item being synced.
+    ///
+    /// Off by default, because nothing automatic ever touches an embedded track: bulk
+    /// runs, schedules and the webhook all skip them on purpose. Counting them anyway
+    /// left every release with an external .srt and a handful of embedded tracks stuck on
+    /// "partly synced" forever, with no way to finish it short of syncing tracks nobody
+    /// asked for. Turn it on if you do sync embedded tracks by hand and want them
+    /// counted.
+    /// </summary>
+    public bool CountEmbeddedSubtitlesInStatus { get; set; }
+
+    /// <summary>
     /// Gets or sets the Google Cloud Translation API key.
     /// </summary>
     public string? GoogleTranslateApiKey { get; set; }
@@ -145,6 +158,19 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the default confidence threshold (0-100) for translation jobs.
     /// </summary>
     public int TranslationConfidenceThreshold { get; set; } = 70;
+
+    /// <summary>
+    /// Gets or sets the language a translation job starts on when nobody names one, e.g.
+    /// "da". Only fills the box in: every job still says what it's translating into. This
+    /// is what stops the language having to be typed on a TV remote every time.
+    /// </summary>
+    public string? TranslationDefaultTargetLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language translation jobs assume the subtitle is in, or null to
+    /// let the provider detect it.
+    /// </summary>
+    public string? TranslationDefaultSourceLanguage { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether translated files get a comment block at the

--- a/Jellyfin.Plugin.Lapse/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lapse/Configuration/configPage.html
@@ -21,6 +21,9 @@
             <div class="lapseQueueStrip hide" id="lapseQueueSection">
                 <div class="lapseQueueRow">
                     <span id="lapseQueueText" class="fieldDescription"></span>
+                    <button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseQueueStop">
+                        <span>Stop</span>
+                    </button>
                 </div>
                 <progress id="lapseQueueBar" max="100" value="0"></progress>
             </div>
@@ -182,7 +185,17 @@
                         </div>
                         <div class="fieldDescription lapseTightNote">
                             Items with no external subtitle are hidden by default. An item counts as synced
-                            once every external subtitle it currently has been synced at least once.
+                            once every subtitle it currently has been synced at least once.
+                        </div>
+                        <label class="emby-checkbox-label lapseStackedCheck">
+                            <input id="lapseCountEmbedded" type="checkbox" is="emby-checkbox" />
+                            <span>Count tracks inside the video file as well</span>
+                        </label>
+                        <div class="fieldDescription lapseTightNote">
+                            Off by default. Nothing automatic syncs a track that is still inside the video
+                            file, so counting them keeps a release with an external .srt and a few embedded
+                            tracks on "partly synced" whatever you do. Turn this on if you sync embedded
+                            tracks by hand and want them to count. Saved straight away.
                         </div>
                         <div id="lapseItemList" class="paperList lapseItemList"></div>
                     </section>
@@ -466,7 +479,16 @@
                     </section>
 
                     <section class="lapsePanel" id="lapsePanelTranslation">
-                        <h2 class="lapsePanelTitle">Translation</h2>
+                        <h2 class="lapsePanelTitle">
+                            Translation
+                            <span class="lapseChip lapseChip-experimental">Experimental</span>
+                        </h2>
+                        <div class="lapseNoteStrip">
+                            Translation is experimental. It sends your subtitle text to a translation service
+                            outside Jellyfin, quality varies a lot by provider and language, and a provider
+                            changing its API or rate limits can break it. None of it is needed for normal
+                            syncing.
+                        </div>
                         <div class="fieldDescription lapseTightNote">
                             <strong>To use this:</strong> press Advanced on an item, either from its three-dot
                             menu or from the <strong>Sync status</strong> list, then use the Translate box in
@@ -485,6 +507,22 @@
                             <select is="emby-select" id="lapseDefaultProvider" class="emby-select-withcolor emby-select"></select>
                         </div>
                         <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="lapseDefaultTargetLanguage">Translate into</label>
+                            <input is="emby-input" id="lapseDefaultTargetLanguage" type="text" placeholder="da" />
+                            <div class="fieldDescription">
+                                Fills the "To" box in on every Translate dialog, so the language does not have
+                                to be typed in each time - which matters on a TV remote. Two letter code, e.g.
+                                da, es, de. Leave empty to type it yourself.
+                            </div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="lapseDefaultSourceLanguage">Translate from</label>
+                            <input is="emby-input" id="lapseDefaultSourceLanguage" type="text" placeholder="auto" />
+                            <div class="fieldDescription">
+                                Leave empty to let the provider work out what language the subtitle is in.
+                            </div>
+                        </div>
+                        <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="lapseConfidence">Confidence threshold</label>
                             <input is="emby-input" id="lapseConfidence" type="number" min="0" max="100" />
                             <div class="fieldDescription">
@@ -501,6 +539,11 @@
                             <input id="lapseMetadataHeader" type="checkbox" is="emby-checkbox" />
                             <span>Include a translation metadata header in the output file</span>
                         </label>
+                        <div class="fieldDescription lapseTightNote">
+                            Applies to every translation, by hand or unattended, and the Translate dialog
+                            starts on whatever is set here. Skipped for .srt files, which have no comment
+                            syntax, so the header cannot be added without breaking them.
+                        </div>
                         <button is="emby-button" type="button" id="btnSaveTranslation" class="raised button-submit lapseSmallButton">
                             <span>Save translation settings</span>
                         </button>

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
@@ -42,6 +42,18 @@
 
 .lapseQueueRow {
     margin-bottom: .4em;
+    display: flex;
+    align-items: center;
+    gap: .8em;
+}
+
+.lapseQueueRow #lapseQueueText {
+    flex: 1;
+}
+
+.lapseQueueRow button {
+    margin: 0;
+    flex: none;
 }
 
 .lapseQueueStrip progress {
@@ -304,6 +316,13 @@
 
 .lapseLibraryRow:last-child {
     border-bottom: 0;
+}
+
+/* Just enough dimming to read as "nothing here can be turned on right now" without
+   making the row hard to read - the library name and type stay full strength since
+   those are what you'd click to turn it back on. */
+.lapseLibraryRowDisabled .lapseLibrarySchedule {
+    opacity: .5;
 }
 
 .lapseLibraryMain {

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
@@ -1239,9 +1239,23 @@
                 frequencySelect.disabled = !scheduled;
                 timeInput.disabled = !scheduled;
                 daySelect.disabled = !needsDay;
+
+                // A row nobody can act on reads as inert, not just as a row with two
+                // greyed out boxes in it.
+                row.classList.toggle('lapseLibraryRowDisabled', !enabledCheck.checked);
             }
 
-            enabledCheck.addEventListener('change', syncRowState);
+            // Turning the library off takes new-item and schedule sync with it, rather
+            // than leaving them ticked-but-inert. Otherwise turning the library back on
+            // later quietly brings a setting back that nobody re-chose.
+            enabledCheck.addEventListener('change', function () {
+                if (!enabledCheck.checked) {
+                    autoSyncCheck.checked = false;
+                    scheduleCheck.checked = false;
+                }
+
+                syncRowState();
+            });
             frequencySelect.addEventListener('change', syncRowState);
             syncRowState();
         });
@@ -1473,10 +1487,16 @@
                 var plural = snapshot.Total === 1 ? unit : unit + 's';
 
                 view.querySelector('#lapseQueueBar').value = pct;
-                view.querySelector('#lapseQueueText').textContent =
-                    (snapshot.JobName ? snapshot.JobName + ': ' : '') +
-                    snapshot.Completed + ' / ' + snapshot.Total + ' ' + plural + ' processed' +
-                    (snapshot.CurrentItemName ? (' - ' + snapshot.CurrentItemName) : '');
+                view.querySelector('#lapseQueueText').textContent = snapshot.Cancelling
+                    ? 'Stopping after the item that is running now...'
+                    : ((snapshot.JobName ? snapshot.JobName + ': ' : '') +
+                        snapshot.Completed + ' / ' + snapshot.Total + ' ' + plural + ' processed' +
+                        (snapshot.CurrentItemName ? (' - ' + snapshot.CurrentItemName) : ''));
+
+                var stopButton = view.querySelector('#lapseQueueStop');
+                if (stopButton) {
+                    stopButton.disabled = !!snapshot.Cancelling;
+                }
             } else if (queueWasRunning) {
                 // Only on the tick where a job finished. Doing it whenever the queue is
                 // idle meant Lapse/Status - which walks every item in every enabled
@@ -1874,18 +1894,31 @@
         var multiTrackHtml = subtitles.length > 1
             ? '<hr class="lapseDialogRule" />' +
               '<div class="selectContainer">' +
-              '  <label class="selectLabel">Sync all subtitles to this one</label>' +
+              '  <label class="selectLabel">Reference (the subtitle that is already correct)</label>' +
               '  <select is="emby-select" id="lapseAdvReference" class="emby-select-withcolor emby-select">' +
               subtitleOptionsHtml(subtitles) +
               '  </select>' +
               '</div>' +
-              '<div class="fieldDescription lapseTightNote">Lines the other ' + (subtitles.length - 1) +
-              ' subtitle' + (subtitles.length === 2 ? '' : 's') + ' up against this one instead of against the audio. Faster and usually more accurate, as long as this one is right.</div>' +
-              '<button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseAdvSyncAll"><span>Sync all to reference</span></button>'
+              '<div class="selectContainer">' +
+              '  <label class="selectLabel">Sync to it</label>' +
+              '  <select is="emby-select" id="lapseAdvReferenceTarget" class="emby-select-withcolor emby-select">' +
+              '    <option value="">Every other subtitle</option>' +
+              subtitleOptionsHtml(subtitles) +
+              '  </select>' +
+              '</div>' +
+              '<div class="fieldDescription lapseTightNote">Lines the tracks up against the reference instead of against the audio. ' +
+              'Faster and usually more accurate, as long as the reference is right. Pick a single track when only one of them is off.</div>' +
+              '<button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseAdvSyncAll"><span>Sync to reference</span></button>'
             : '';
 
         var providers = configuredProviders();
         var threshold = (currentSettings && currentSettings.TranslationConfidenceThreshold) || 70;
+
+        // The languages set under Translation fill the boxes in, so a manual run starts
+        // where the settings say rather than empty every time.
+        var defaultTarget = (currentSettings &&
+            (currentSettings.TranslationDefaultTargetLanguage || currentSettings.AutoTranslateLanguage)) || '';
+        var defaultSource = (currentSettings && currentSettings.TranslationDefaultSourceLanguage) || '';
 
         var translationHtml = (subtitles.length > 0 && providers.length > 0)
             ? '<hr class="lapseDialogRule" />' +
@@ -1893,11 +1926,13 @@
               '<div class="lapseFieldPair">' +
               '  <div class="inputContainer">' +
               '    <label class="inputLabel inputLabelUnfocused">From</label>' +
-              '    <input is="emby-input" id="lapseAdvSourceLang" type="text" placeholder="auto" />' +
+              '    <input is="emby-input" id="lapseAdvSourceLang" type="text" placeholder="auto" value="' +
+              escapeHtml(defaultSource) + '" />' +
               '  </div>' +
               '  <div class="inputContainer">' +
               '    <label class="inputLabel inputLabelUnfocused">To</label>' +
-              '    <input is="emby-input" id="lapseAdvTargetLang" type="text" placeholder="es" />' +
+              '    <input is="emby-input" id="lapseAdvTargetLang" type="text" placeholder="es" value="' +
+              escapeHtml(defaultTarget) + '" />' +
               '  </div>' +
               '</div>' +
               '<div class="selectContainer">' +
@@ -1919,7 +1954,8 @@
               ((currentSettings && currentSettings.TranslationIncludeMetadataHeader) ? ' checked' : '') + ' />' +
               '  <span>Add a metadata comment block at the top</span>' +
               '</label>' +
-              '<div class="fieldDescription lapseTightNote">Writes a new file next to the original, never over it.</div>' +
+              '<div class="fieldDescription lapseTightNote">Writes a new file next to the original, never over it. ' +
+              'The comment block is skipped for .srt, which has no comment syntax to put one in.</div>' +
               '<button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseAdvTranslate"><span>Translate</span></button>'
             : '';
 
@@ -2059,10 +2095,19 @@
         var syncAllButton = overlay.querySelector('#lapseAdvSyncAll');
         if (syncAllButton) {
             syncAllButton.addEventListener('click', function () {
+                var referencePath = overlay.querySelector('#lapseAdvReference').value;
+                var targetPath = overlay.querySelector('#lapseAdvReferenceTarget').value;
+
+                if (targetPath && targetPath === referencePath) {
+                    Dashboard.alert('That is the reference itself. Pick another subtitle, or sync every other one.');
+                    return;
+                }
+
                 Dashboard.showLoadingMsg();
                 lapsePost('Lapse/SyncAllSubtitles', {
                     ItemId: itemId,
-                    ReferencePath: overlay.querySelector('#lapseAdvReference').value,
+                    ReferencePath: referencePath,
+                    SubtitlePaths: targetPath ? [targetPath] : null,
                     EngineId: currentEngine().Id,
                     Mode: modeSelect.value,
                     Penalty: currentPenalty()
@@ -2768,6 +2813,9 @@
         view.querySelector('#lapseConfidence').value = currentSettings.TranslationConfidenceThreshold;
         view.querySelector('#lapseKeepLowConfidence').checked = !!currentSettings.TranslationKeepLowConfidenceOriginal;
         view.querySelector('#lapseMetadataHeader').checked = !!currentSettings.TranslationIncludeMetadataHeader;
+        view.querySelector('#lapseCountEmbedded').checked = !!currentSettings.CountEmbeddedSubtitlesInStatus;
+        view.querySelector('#lapseDefaultTargetLanguage').value = currentSettings.TranslationDefaultTargetLanguage || '';
+        view.querySelector('#lapseDefaultSourceLanguage').value = currentSettings.TranslationDefaultSourceLanguage || '';
 
         view.querySelector('#lapseSubToSubPlacement').value = currentSettings.SubToSubPlacement || 'ReferenceFolder';
         view.querySelector('#lapseSubToSubCustomFolder').value = currentSettings.SubToSubCustomFolder || '';
@@ -3020,6 +3068,7 @@
             LowConfidenceAction: selectedRadio(view, 'lapseLowConfidence', 'Sidecar'),
             ConfidenceSigma: parseFloat(view.querySelector('#lapseConfidenceSigma').value) || 8,
             AutoUpdateEngines: view.querySelector('#lapseAutoUpdateEngines').checked,
+            CountEmbeddedSubtitlesInStatus: view.querySelector('#lapseCountEmbedded').checked,
             SubToSubPlacement: view.querySelector('#lapseSubToSubPlacement').value,
             SubToSubCustomFolder: view.querySelector('#lapseSubToSubCustomFolder').value || null,
             OpenSubtitlesEnabled: view.querySelector('#lapseOpenSubtitlesEnabled').checked,
@@ -3039,6 +3088,8 @@
             TranslationConfidenceThreshold: parseInt(view.querySelector('#lapseConfidence').value, 10) || 0,
             TranslationKeepLowConfidenceOriginal: view.querySelector('#lapseKeepLowConfidence').checked,
             TranslationIncludeMetadataHeader: view.querySelector('#lapseMetadataHeader').checked,
+            TranslationDefaultTargetLanguage: view.querySelector('#lapseDefaultTargetLanguage').value.trim() || null,
+            TranslationDefaultSourceLanguage: view.querySelector('#lapseDefaultSourceLanguage').value.trim() || null,
             SubtitleAppearance: currentAppearance(view),
             Engines: []
         };
@@ -3187,6 +3238,28 @@
 
         startQueuePolling(view);
 
+        view.querySelector('#lapseQueueStop').addEventListener('click', function () {
+            var button = view.querySelector('#lapseQueueStop');
+            button.disabled = true;
+
+            lapsePost('Lapse/Queue/Cancel').then(function () {
+                refreshQueue(view);
+            }).catch(function (err) {
+                button.disabled = false;
+                Dashboard.alert('Could not stop the job: ' + err.message);
+            });
+        });
+        // A filter-like toggle sitting above the list, so it saves itself rather than
+        // waiting for a Save button on a page that hasn't got one.
+        view.querySelector('#lapseCountEmbedded').addEventListener('change', function () {
+            lapsePost('Lapse/Settings', collectSettings(view)).then(function () {
+                return refreshSettings(view);
+            }).then(function () {
+                return Promise.all([refreshItemList(view), refreshOverview(view)]);
+            }).catch(function (err) {
+                Dashboard.alert('Could not save: ' + err.message);
+            });
+        });
         view.querySelector('#lapseItemSearch').addEventListener('input', function () {
             renderItemList(view, allItems);
         });

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.css
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.css
@@ -182,7 +182,21 @@
     margin: .6em 0;
 }
 
+.lapseToast .lapseToastText {
+    flex: 1;
+}
+
+.lapseToast .lapseToastButton {
+    margin: 0;
+    flex: none;
+    padding: .2em .8em;
+    font-size: .9em;
+}
+
 .lapseToast {
+    display: flex;
+    align-items: center;
+    gap: .8em;
     position: fixed;
     left: 50%;
     bottom: 4em;

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
@@ -394,7 +394,7 @@
                 openConvertPopup(context);
             }));
 
-            scroller.appendChild(makeMenuButton('lapse-sync-all-subtitles', 'Sync All Subtitles to Reference', 'compare_arrows', function () {
+            scroller.appendChild(makeMenuButton('lapse-sync-all-subtitles', 'Sync Subtitles to Reference', 'compare_arrows', function () {
                 openReferencePopup(context);
             }));
         }
@@ -1011,7 +1011,7 @@
         return String(value).padStart(width, '0');
     }
 
-    // --- "Sync All Subtitles to Reference" on a single item ---
+    // --- "Sync Subtitles to Reference" on a single item ---
 
     function openReferencePopup(context) {
         showLapseToast('Checking subtitles...');
@@ -1023,10 +1023,18 @@
             }
 
             var overlay = openOverlay(
-                '<h3>Sync All Subtitles to Reference</h3>' +
-                '<p class="fieldDescription">Pick the subtitle that is already correct. Every other subtitle on this item gets lined up against it.</p>' +
+                '<h3>Sync Subtitles to Reference</h3>' +
+                '<p class="fieldDescription">Pick the subtitle that is already correct, then say what to line up against it.</p>' +
                 '<div class="selectContainer">' +
+                '<label class="selectLabel">Reference (the correct one)</label>' +
                 '<select is="emby-select" id="lapseRefSelect" class="emby-select-withcolor emby-select">' +
+                subtitleOptionsHtml(subtitles) +
+                '</select>' +
+                '</div>' +
+                '<div class="selectContainer">' +
+                '<label class="selectLabel">Sync</label>' +
+                '<select is="emby-select" id="lapseRefTarget" class="emby-select-withcolor emby-select">' +
+                '<option value="">Every other subtitle</option>' +
                 subtitleOptionsHtml(subtitles) +
                 '</select>' +
                 '</div>' +
@@ -1035,30 +1043,44 @@
                 '<button is="emby-button" type="button" class="raised button-submit" id="lapseRefSync"><span>Sync</span></button>' +
                 '</div>');
 
+            var referenceSelect = overlay.querySelector('#lapseRefSelect');
+            var targetSelect = overlay.querySelector('#lapseRefTarget');
+
             overlay.querySelector('#lapseRefCancel').addEventListener('click', function () {
                 overlay.remove();
             });
 
             overlay.querySelector('#lapseRefSync').addEventListener('click', function () {
-                var referencePath = overlay.querySelector('#lapseRefSelect').value;
+                var referencePath = referenceSelect.value;
+                var targetPath = targetSelect.value;
+
+                if (targetPath && targetPath === referencePath) {
+                    showLapseToast('That is the reference itself. Pick another subtitle, or sync every other one.');
+                    return;
+                }
+
                 overlay.remove();
-                doSyncAll(context.id, referencePath, subtitles.length - 1);
+                doSyncAll(context.id, referencePath, targetPath ? 1 : subtitles.length - 1,
+                    targetPath ? [targetPath] : null);
             });
         }).catch(function (err) {
             showLapseToast('Could not check subtitles: ' + err.message);
         });
     }
 
-    function doSyncAll(itemId, referencePath, count) {
+    // subtitlePaths names the tracks to sync, or null for every track except the
+    // reference.
+    function doSyncAll(itemId, referencePath, count, subtitlePaths) {
         showLapseToast('Syncing ' + count + ' subtitle' + (count === 1 ? '' : 's') + ' to the reference...');
 
         lapsePost('Lapse/SyncAllSubtitles', {
             ItemId: itemId,
-            ReferencePath: referencePath
+            ReferencePath: referencePath,
+            SubtitlePaths: subtitlePaths || null
         }).then(function (result) {
             var failed = result.Results.length - result.SucceededCount;
             showLapseToast(failed === 0
-                ? ('Synced all ' + result.SucceededCount + ' subtitles to the reference.')
+                ? ('Synced ' + result.SucceededCount + ' subtitle' + (result.SucceededCount === 1 ? '' : 's') + ' to the reference.')
                 : (result.SucceededCount + ' of ' + result.Results.length + ' synced, ' + failed + ' failed. See the LAPSE dashboard for details.'));
         }).catch(function (err) {
             showLapseToast('Sync failed: ' + err.message);
@@ -1128,7 +1150,27 @@
             return;
         }
 
-        var toast = showLapseToast('Starting...', true);
+        var toast = showLapseToast('', true);
+
+        // The toast carries the Stop button, so a job that turns out to be the wrong one
+        // can be called off from wherever it was started rather than only from the
+        // dashboard.
+        toast.innerHTML = '<span class="lapseToastText">Starting...</span>' +
+            '<button is="emby-button" type="button" class="raised lapseToastButton" id="lapseProgressStop">' +
+            '<span>Stop</span></button>';
+
+        var text = toast.querySelector('.lapseToastText');
+        var stopButton = toast.querySelector('#lapseProgressStop');
+
+        stopButton.addEventListener('click', function () {
+            stopButton.disabled = true;
+            text.textContent = 'Stopping...';
+
+            lapsePost('Lapse/Queue/Cancel').catch(function (err) {
+                stopButton.disabled = false;
+                text.textContent = 'Could not stop the job: ' + err.message;
+            });
+        });
 
         function poll() {
             lapseGet('Lapse/Queue').then(function (snapshot) {
@@ -1136,14 +1178,19 @@
                 var plural = snapshot.Total === 1 ? unit : unit + 's';
 
                 if (snapshot.Running) {
-                    toast.textContent = (snapshot.JobName ? snapshot.JobName + ': ' : '') +
-                        snapshot.Completed + ' / ' + snapshot.Total + ' ' + plural + ' processed' +
-                        (snapshot.CurrentItemName ? ' - ' + snapshot.CurrentItemName : '');
+                    text.textContent = snapshot.Cancelling
+                        ? 'Stopping after the item that is running now...'
+                        : ((snapshot.JobName ? snapshot.JobName + ': ' : '') +
+                            snapshot.Completed + ' / ' + snapshot.Total + ' ' + plural + ' processed' +
+                            (snapshot.CurrentItemName ? ' - ' + snapshot.CurrentItemName : ''));
+
+                    stopButton.disabled = !!snapshot.Cancelling;
                     return;
                 }
 
                 stopProgressPolling();
-                toast.textContent = (snapshot.JobName ? snapshot.JobName + ': ' : '') +
+                stopButton.remove();
+                text.textContent = (snapshot.JobName ? snapshot.JobName + ': ' : '') +
                     'finished, ' + snapshot.Completed + ' / ' + snapshot.Total + ' ' + plural + ' processed.';
 
                 setTimeout(function () {
@@ -1153,7 +1200,7 @@
                 }, 8000);
             }).catch(function (err) {
                 stopProgressPolling();
-                toast.textContent = 'Lost track of the sync job: ' + err.message;
+                text.textContent = 'Lost track of the sync job: ' + err.message;
             });
         }
 
@@ -1180,20 +1227,25 @@
         Promise.all([
             lapseGet('Lapse/Items/' + context.id + '/Subtitles'),
             lapseGet('Lapse/Engines'),
-            lapseGet('Lapse/Translate/Providers')
+            lapseGet('Lapse/Translate/Providers'),
+            lapseGet('Lapse/Translate/Defaults')
         ]).then(function (results) {
             var toast = document.querySelector('.lapseToast');
             if (toast) {
                 toast.remove();
             }
 
-            showAdvancedDialog(context, results[0], results[1], results[2]);
+            showAdvancedDialog(context, results[0], results[1], results[2], results[3] || {});
         }).catch(function (err) {
             showLapseToast('Could not open the advanced options: ' + err.message);
         });
     }
 
-    function showAdvancedDialog(context, subtitles, engines, providers) {
+    // The dialog reads top to bottom as one run: which subtitle, what to line it up
+    // against, how to write the result, and whether to translate what comes out. Every
+    // button that starts something is in the row at the bottom, so no action is hiding
+    // underneath a setting.
+    function showAdvancedDialog(context, subtitles, engines, providers, defaults) {
         var usableEngines = engines.filter(function (e) { return e.Installed && !e.RunCheckError; });
         if (usableEngines.length === 0) {
             showLapseToast('No engine is installed and working. Install one from the LAPSE dashboard first.');
@@ -1201,8 +1253,9 @@
         }
 
         var configuredProviders = (providers || []).filter(function (p) { return p.Configured; });
-
+        var canTranslate = subtitles.length > 0 && configuredProviders.length > 0;
         var startEngine = usableEngines.filter(function (e) { return e.IsDefault; })[0] || usableEngines[0];
+        var threshold = typeof defaults.ConfidenceThreshold === 'number' ? defaults.ConfidenceThreshold : 70;
 
         var engineOptions = usableEngines.map(function (e) {
             return '<option value="' + escapeHtml(e.Id) + '"' + (e.Id === startEngine.Id ? ' selected' : '') + '>' +
@@ -1210,61 +1263,85 @@
         }).join('');
 
         var subtitleSection = subtitles.length === 0
-            ? '<p class="fieldDescription">No external subtitle found for this item.</p>'
+            ? '<p class="fieldDescription">No subtitle found for this item.</p>'
             : '<div class="selectContainer">' +
               '  <label class="selectLabel">Subtitle</label>' +
               '  <select is="emby-select" id="lapseAdvSubtitle" class="emby-select-withcolor emby-select">' +
               subtitleOptionsHtml(subtitles) +
               '  </select>' +
+              '  <div class="fieldDescription">Tracks still inside the video file are pulled out first, so an embedded one can be picked here too.</div>' +
               '</div>';
 
+        // Syncing against another subtitle used to be a second button further down the
+        // dialog. It's the same run with a different thing to line up against, so it's a
+        // dropdown here and the Sync button does both.
         var referenceSection = subtitles.length > 1
-            ? '<hr class="lapseDialogRule" />' +
-              '<div class="selectContainer">' +
-              '  <label class="selectLabel">Sync all subtitles to this one</label>' +
+            ? '<div class="selectContainer">' +
+              '  <label class="selectLabel">Line it up against</label>' +
               '  <select is="emby-select" id="lapseAdvReference" class="emby-select-withcolor emby-select">' +
+              '    <option value="">The audio in the video</option>' +
               subtitleOptionsHtml(subtitles) +
               '  </select>' +
+              '  <div class="fieldDescription">Another subtitle skips the audio entirely. Faster and usually more accurate, as long as the one you pick is correct.</div>' +
               '</div>' +
-              '<button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseAdvSyncAll"><span>Sync all to reference</span></button>'
+              '<label class="emby-checkbox-label lapseStackedCheck hide" id="lapseAdvSyncAllRow">' +
+              '  <input type="checkbox" is="emby-checkbox" id="lapseAdvSyncAll" />' +
+              '  <span>Sync every other subtitle to it, not just the one above</span>' +
+              '</label>'
             : '';
 
-        var translationSection = (subtitles.length > 0 && configuredProviders.length > 0)
+        var translationSection = canTranslate
             ? '<hr class="lapseDialogRule" />' +
               '<h4 class="lapseDialogSubhead">Translate</h4>' +
+              '<label class="emby-checkbox-label lapseStackedCheck">' +
+              '  <input type="checkbox" is="emby-checkbox" id="lapseAdvAlsoTranslate" />' +
+              '  <span>Translate as well when Sync runs</span>' +
+              '</label>' +
+              '<div class="fieldDescription">Ticked, Sync does the lot in one go: converts the format if you picked one, ' +
+              'lines the subtitle up, then translates the result. Translate on its own only translates.</div>' +
               '<div class="lapseFieldPair">' +
               '  <div class="inputContainer">' +
               '    <label class="inputLabel inputLabelUnfocused">From</label>' +
-              '    <input is="emby-input" id="lapseAdvSourceLang" type="text" placeholder="auto" />' +
+              '    <input is="emby-input" id="lapseAdvSourceLang" type="text" placeholder="auto" value="' +
+              escapeHtml(defaults.SourceLanguage || '') + '" />' +
               '  </div>' +
               '  <div class="inputContainer">' +
               '    <label class="inputLabel inputLabelUnfocused">To</label>' +
-              '    <input is="emby-input" id="lapseAdvTargetLang" type="text" placeholder="es" />' +
+              '    <input is="emby-input" id="lapseAdvTargetLang" type="text" placeholder="es" value="' +
+              escapeHtml(defaults.TargetLanguage || '') + '" />' +
               '  </div>' +
               '</div>' +
               '<div class="selectContainer">' +
               '  <label class="selectLabel">Provider</label>' +
               '  <select is="emby-select" id="lapseAdvProvider" class="emby-select-withcolor emby-select">' +
               configuredProviders.map(function (p) {
-                  return '<option value="' + escapeHtml(p.Id) + '"' + (p.IsDefault ? ' selected' : '') + '>' +
+                  var selected = defaults.Provider ? p.Id === defaults.Provider : p.IsDefault;
+                  return '<option value="' + escapeHtml(p.Id) + '"' + (selected ? ' selected' : '') + '>' +
                       escapeHtml(p.DisplayName) + '</option>';
               }).join('') +
               '  </select>' +
               '</div>' +
               '<div class="inputContainer">' +
-              '  <label class="inputLabel inputLabelUnfocused">Confidence threshold: <span id="lapseAdvConfidenceValue">70</span>%</label>' +
-              '  <input type="range" id="lapseAdvConfidence" min="0" max="100" value="70" class="lapseRange" />' +
+              '  <label class="inputLabel inputLabelUnfocused">Confidence threshold: <span id="lapseAdvConfidenceValue">' +
+              threshold + '</span>%</label>' +
+              '  <input type="range" id="lapseAdvConfidence" min="0" max="100" value="' + threshold + '" class="lapseRange" />' +
               '</div>' +
               '<label class="emby-checkbox-label lapseStackedCheck">' +
-              '  <input id="lapseAdvMetadataHeader" type="checkbox" is="emby-checkbox" checked />' +
+              '  <input id="lapseAdvMetadataHeader" type="checkbox" is="emby-checkbox"' +
+              (defaults.IncludeMetadataHeader ? ' checked' : '') + ' />' +
               '  <span>Add a metadata comment block at the top</span>' +
               '</label>' +
-              '<div class="fieldDescription">Writes a new file next to the original, never over it.</div>' +
-              '<button is="emby-button" type="button" class="raised lapseSmallButton" id="lapseAdvTranslate"><span>Translate</span></button>'
+              '<div class="fieldDescription">Skipped for .srt, which has no comment syntax to put one in. ' +
+              'A translation always writes a new file next to the original, never over it.</div>'
             : '';
 
         var overlay = openOverlay(
             '<h3>' + escapeHtml(context.name || 'Advanced') + '</h3>' +
+            '<h4 class="lapseDialogSubhead">What to sync</h4>' +
+            subtitleSection +
+            referenceSection +
+            '<hr class="lapseDialogRule" />' +
+            '<h4 class="lapseDialogSubhead">How</h4>' +
             '<div class="selectContainer">' +
             '  <label class="selectLabel">Engine</label>' +
             '  <select is="emby-select" id="lapseAdvEngine" class="emby-select-withcolor emby-select">' + engineOptions + '</select>' +
@@ -1280,7 +1357,8 @@
             '  <input is="emby-input" id="lapseAdvPenalty" type="number" value="' + startEngine.Penalty + '" />' +
             '  <div class="fieldDescription" id="lapseAdvPenaltyNote"></div>' +
             '</div>' +
-            subtitleSection +
+            '<hr class="lapseDialogRule" />' +
+            '<h4 class="lapseDialogSubhead">Where it goes</h4>' +
             '<div class="selectContainer">' +
             '  <label class="selectLabel">Write the result as</label>' +
             '  <select is="emby-select" id="lapseAdvFormat" class="emby-select-withcolor emby-select">' +
@@ -1303,19 +1381,15 @@
             '  </select>' +
             '  <div class="fieldDescription">Just for this run. The default is on the File output page.</div>' +
             '</div>' +
-            '<label class="emby-checkbox-label lapseStackedCheck">' +
-            '  <input type="checkbox" is="emby-checkbox" id="lapseAdvAlsoTranslate" />' +
-            '  <span>Translate it as well, using the boxes further down</span>' +
-            '</label>' +
-            '<div class="fieldDescription">Ticked, Sync does all of it in one go: converts the format if ' +
-            'you picked one, lines it up, then translates what came out. Left alone, Sync only syncs.</div>' +
+            translationSection +
             '<div class="lapseDialogButtons">' +
             '  <button is="emby-button" type="button" class="raised" id="lapseAdvClose"><span>Close</span></button>' +
+            (canTranslate
+                ? '  <button is="emby-button" type="button" class="raised" id="lapseAdvTranslate"><span>Translate only</span></button>'
+                : '') +
             '  <button is="emby-button" type="button" class="raised button-submit" id="lapseAdvSync"' +
             (subtitles.length === 0 ? ' disabled' : '') + '><span>Sync</span></button>' +
-            '</div>' +
-            referenceSection +
-            translationSection,
+            '</div>',
             true);
 
         var engineSelect = overlay.querySelector('#lapseAdvEngine');
@@ -1323,6 +1397,10 @@
         var penaltyContainer = overlay.querySelector('#lapseAdvPenaltyContainer');
         var penaltyInput = overlay.querySelector('#lapseAdvPenalty');
         var penaltyNote = overlay.querySelector('#lapseAdvPenaltyNote');
+        var referenceSelect = overlay.querySelector('#lapseAdvReference');
+        var syncAllRow = overlay.querySelector('#lapseAdvSyncAllRow');
+        var syncAllCheck = overlay.querySelector('#lapseAdvSyncAll');
+        var confidenceSlider = overlay.querySelector('#lapseAdvConfidence');
 
         function currentEngine() {
             return usableEngines.filter(function (e) { return e.Id === engineSelect.value; })[0] || startEngine;
@@ -1346,6 +1424,20 @@
         modeSelect.addEventListener('change', syncPenaltyVisibility);
         syncPenaltyVisibility();
 
+        // "Sync every other subtitle to it" only means anything once a reference track is
+        // picked, so it stays out of the way until then.
+        function syncReferenceState() {
+            var usingReference = !!(referenceSelect && referenceSelect.value);
+            if (syncAllRow) {
+                syncAllRow.classList.toggle('hide', !usingReference);
+            }
+        }
+
+        if (referenceSelect) {
+            referenceSelect.addEventListener('change', syncReferenceState);
+            syncReferenceState();
+        }
+
         function selectedSubtitlePath() {
             var select = overlay.querySelector('#lapseAdvSubtitle');
             return select ? select.value : null;
@@ -1362,53 +1454,14 @@
             overlay.remove();
         });
 
-        overlay.querySelector('#lapseAdvSync').addEventListener('click', function () {
-            var alsoTranslate = overlay.querySelector('#lapseAdvAlsoTranslate').checked;
-            var translation = alsoTranslate ? collectTranslationRequest() : null;
-
-            if (alsoTranslate && !translation) {
-                showLapseToast('Fill in the target language further down before asking for a translation too.');
-                return;
-            }
-
-            overlay.remove();
-            showLapseToast(alsoTranslate ? 'Syncing and translating...' : 'Syncing...');
-
-            lapsePost('Lapse/Pipeline', {
-                ItemId: context.id,
-                SubtitlePath: selectedSubtitlePath(),
-                EngineId: currentEngine().Id,
-                Mode: modeSelect.value,
-                Penalty: currentPenalty(),
-                Sync: true,
-                OutputFormat: overlay.querySelector('#lapseAdvFormat').value || null,
-                OutputMode: overlay.querySelector('#lapseAdvOutputMode').value || null,
-                Translation: translation
-            }).then(function (result) {
-                showLapseToast(describePipelineOutcome(result));
-            }).catch(function (err) {
-                showLapseToast('Sync failed: ' + err.message);
-            });
-        });
-
-        var syncAllButton = overlay.querySelector('#lapseAdvSyncAll');
-        if (syncAllButton) {
-            syncAllButton.addEventListener('click', function () {
-                var referencePath = overlay.querySelector('#lapseAdvReference').value;
-                overlay.remove();
-                doSyncAll(context.id, referencePath, subtitles.length - 1);
-            });
-        }
-
-        var confidenceSlider = overlay.querySelector('#lapseAdvConfidence');
         if (confidenceSlider) {
             confidenceSlider.addEventListener('input', function () {
                 overlay.querySelector('#lapseAdvConfidenceValue').textContent = confidenceSlider.value;
             });
         }
 
-        // The translation boxes are further down the same dialog, so a combined run can
-        // read them without asking twice.
+        // The translation boxes are part of the same dialog, so a combined run reads them
+        // without asking twice.
         function collectTranslationRequest() {
             var targetInput = overlay.querySelector('#lapseAdvTargetLang');
             var target = targetInput ? (targetInput.value || '').trim() : '';
@@ -1417,48 +1470,115 @@
                 return null;
             }
 
-            var slider = overlay.querySelector('#lapseAdvConfidence');
-
             return {
                 ItemId: context.id,
                 SubtitlePath: selectedSubtitlePath(),
                 SourceLanguage: (overlay.querySelector('#lapseAdvSourceLang').value || '').trim() || null,
                 TargetLanguage: target,
                 Provider: overlay.querySelector('#lapseAdvProvider').value,
-                ConfidenceThreshold: slider ? parseInt(slider.value, 10) : 70,
+                ConfidenceThreshold: confidenceSlider ? parseInt(confidenceSlider.value, 10) : threshold,
                 IncludeMetadataHeader: overlay.querySelector('#lapseAdvMetadataHeader').checked
             };
         }
 
+        function runTranslation(job, prefix) {
+            showLapseToast(prefix + 'translating into ' + job.TargetLanguage + '...');
+
+            return lapsePost('Lapse/Translate', job).then(function (result) {
+                showLapseToast(result.Success
+                    ? ('Translated ' + result.TranslatedCount + ' of ' + result.LineCount + ' lines. Wrote ' + result.OutputPath)
+                    : ('Translation failed: ' + result.Error));
+            }).catch(function (err) {
+                showLapseToast('Translation failed: ' + err.message);
+            });
+        }
+
+        overlay.querySelector('#lapseAdvSync').addEventListener('click', function () {
+            var alsoTranslateBox = overlay.querySelector('#lapseAdvAlsoTranslate');
+            var alsoTranslate = !!(alsoTranslateBox && alsoTranslateBox.checked);
+            var translation = alsoTranslate ? collectTranslationRequest() : null;
+
+            if (alsoTranslate && !translation) {
+                showLapseToast('Fill in the language to translate into before asking for a translation too.');
+                return;
+            }
+
+            var subtitlePath = selectedSubtitlePath();
+            var referencePath = referenceSelect ? referenceSelect.value : '';
+            var syncAll = !!(syncAllCheck && syncAllCheck.checked);
+            var outputFormat = overlay.querySelector('#lapseAdvFormat').value || null;
+            var outputMode = overlay.querySelector('#lapseAdvOutputMode').value || null;
+            var engineId = currentEngine().Id;
+            var mode = modeSelect.value;
+            var penalty = currentPenalty();
+
+            if (referencePath && !syncAll && referencePath === subtitlePath) {
+                showLapseToast('That subtitle is the reference. Pick another one, or tick the box to sync every other subtitle to it.');
+                return;
+            }
+
+            overlay.remove();
+
+            if (referencePath) {
+                var count = syncAll ? subtitles.length - 1 : 1;
+                showLapseToast('Syncing ' + count + ' subtitle' + (count === 1 ? '' : 's') + ' to the reference...');
+
+                lapsePost('Lapse/SyncAllSubtitles', {
+                    ItemId: context.id,
+                    ReferencePath: referencePath,
+                    SubtitlePaths: syncAll ? null : [subtitlePath],
+                    EngineId: engineId,
+                    Mode: mode,
+                    Penalty: penalty,
+                    OutputMode: outputMode
+                }).then(function (result) {
+                    var failed = result.Results.length - result.SucceededCount;
+                    showLapseToast(failed === 0
+                        ? ('Synced ' + result.SucceededCount + ' subtitle' + (result.SucceededCount === 1 ? '' : 's') + ' to the reference.')
+                        : (result.SucceededCount + ' of ' + result.Results.length + ' synced, ' + failed + ' failed. See the LAPSE dashboard for details.'));
+
+                    if (translation && result.SucceededCount > 0) {
+                        return runTranslation(translation, 'Synced, ');
+                    }
+
+                    return null;
+                }).catch(function (err) {
+                    showLapseToast('Sync failed: ' + err.message);
+                });
+
+                return;
+            }
+
+            showLapseToast(alsoTranslate ? 'Syncing and translating...' : 'Syncing...');
+
+            lapsePost('Lapse/Pipeline', {
+                ItemId: context.id,
+                SubtitlePath: subtitlePath,
+                EngineId: engineId,
+                Mode: mode,
+                Penalty: penalty,
+                Sync: true,
+                OutputFormat: outputFormat,
+                OutputMode: outputMode,
+                Translation: translation
+            }).then(function (result) {
+                showLapseToast(describePipelineOutcome(result));
+            }).catch(function (err) {
+                showLapseToast('Sync failed: ' + err.message);
+            });
+        });
+
         var translateButton = overlay.querySelector('#lapseAdvTranslate');
         if (translateButton) {
             translateButton.addEventListener('click', function () {
-                var target = (overlay.querySelector('#lapseAdvTargetLang').value || '').trim();
-                if (!target) {
+                var job = collectTranslationRequest();
+                if (!job) {
                     showLapseToast('Enter the language code to translate into first, e.g. es for Spanish.');
                     return;
                 }
 
-                var job = {
-                    ItemId: context.id,
-                    SubtitlePath: selectedSubtitlePath(),
-                    SourceLanguage: (overlay.querySelector('#lapseAdvSourceLang').value || '').trim() || null,
-                    TargetLanguage: target,
-                    Provider: overlay.querySelector('#lapseAdvProvider').value,
-                    ConfidenceThreshold: parseInt(confidenceSlider.value, 10),
-                    IncludeMetadataHeader: overlay.querySelector('#lapseAdvMetadataHeader').checked
-                };
-
                 overlay.remove();
-                showLapseToast('Translating into ' + target + '...');
-
-                lapsePost('Lapse/Translate', job).then(function (result) {
-                    showLapseToast(result.Success
-                        ? ('Translated ' + result.TranslatedCount + ' of ' + result.LineCount + ' lines. Wrote ' + result.OutputPath)
-                        : ('Translation failed: ' + result.Error));
-                }).catch(function (err) {
-                    showLapseToast('Translation failed: ' + err.message);
-                });
+                runTranslation(job, '');
             });
         }
     }

--- a/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
+++ b/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
@@ -208,6 +208,16 @@ public class LapseController : ControllerBase
             var record = config.MovieRecords.FirstOrDefault(r => r.ItemId == item.Id);
             var subtitles = _subtitleLocator.GetExternalSubtitles(item);
 
+            // Tracks still inside the video file are left out of the count unless the
+            // admin asked for them. Nothing automatic syncs one, so counting them would
+            // hold an item on "partly synced" no matter what was done to its files. A
+            // track that does get synced by hand is written out as a file, and that file
+            // is counted here like any other.
+            if (!config.CountEmbeddedSubtitlesInStatus)
+            {
+                subtitles = subtitles.FindAll(s => !s.IsEmbedded);
+            }
+
             // How many of the subtitles this item has right now have actually been
             // synced. Anything the record claims about a file that is no longer there
             // doesn't count, so a replaced subtitle correctly drops back to unsynced.
@@ -592,17 +602,33 @@ public class LapseController : ControllerBase
             return BadRequest("That reference subtitle doesn't belong to this item");
         }
 
-        // Only ever line something up against a reference that's actually correct.
-        // Picture based tracks have no text to compare, so they can't be a reference.
+        // A picture based track can still be a reference: there's no text in it, but the
+        // timing is right there, and an engine that reads the format lines the others up
+        // against that. So this turns away what the engine actually can't read rather
+        // than a whole class of subtitle.
         if (!reference.Supported)
         {
-            return BadRequest("That's a picture based subtitle (PGS or VobSub), so it can't be used as a reference - there's no text in it.");
+            return BadRequest("The engine can't read that subtitle, so it can't line anything up against it. Picture based tracks (PGS, VobSub) need an engine that reads them.");
         }
 
         var others = subtitles.Where(s => !string.Equals(s.Path, reference.Path, StringComparison.Ordinal) && s.Supported).ToList();
         if (others.Count == 0)
         {
             return BadRequest("This item only has the one usable subtitle, so there's nothing to line up against it");
+        }
+
+        // A request that names subtitles is syncing only those against the reference,
+        // which is what the picker sends when someone wants one track fixed rather than
+        // all of them.
+        if (request.SubtitlePaths is { Count: > 0 })
+        {
+            var wanted = new HashSet<string>(request.SubtitlePaths, StringComparer.Ordinal);
+            others = others.Where(s => wanted.Contains(s.Path)).ToList();
+
+            if (others.Count == 0)
+            {
+                return BadRequest("None of the subtitles you picked belong to this item, or the only one you picked is the reference itself");
+            }
         }
 
         var engine = _registry.Resolve(request.EngineId);
@@ -716,6 +742,29 @@ public class LapseController : ControllerBase
     public ActionResult<QueueSnapshot> GetQueue()
     {
         return _queueManager.GetSnapshot();
+    }
+
+    /// <summary>
+    /// Stops the running job: drops everything still queued and cancels the item being
+    /// synced right now. Subtitles already written stay as they are.
+    /// </summary>
+    /// <returns>How many queued items were dropped, or 409 if nothing was running.</returns>
+    [HttpPost("Lapse/Queue/Cancel")]
+    public ActionResult CancelQueue()
+    {
+        // Anyone who is allowed to start a job from the context menu can stop one. That
+        // is the whole point of the button: a series sync started by mistake shouldn't
+        // need an admin to come and turn it off.
+        if (CheckSubtitleAccess() is { } denied)
+        {
+            return denied;
+        }
+
+        var dropped = _queueManager.Cancel();
+
+        return dropped is null
+            ? Conflict("There is no sync job running")
+            : Ok(new { Dropped = dropped.Value });
     }
 
     /// <summary>
@@ -922,13 +971,19 @@ public class LapseController : ControllerBase
             var oldTime = library.ScheduleTime;
 
             library.Enabled = entry.Enabled;
-            library.AutoSyncEnabled = entry.AutoSyncEnabled;
+
+            // A disabled library can't be doing new-item or scheduled sync - those boxes
+            // are greyed out on the form for exactly that reason - so a disabled library
+            // is stored with both off rather than trusting whatever the form last had
+            // ticked before it was turned off. Otherwise turning the library back on
+            // later would silently bring back a setting nobody re-chose.
+            library.AutoSyncEnabled = entry.Enabled && entry.AutoSyncEnabled;
 
             // New items and a schedule are one choice, not two: a library either picks
             // things up as they arrive or sweeps the whole thing on a timer. The form
             // only ever lets one be ticked, and this is what makes that true of the
             // stored config as well rather than only of the page.
-            library.ScheduleEnabled = entry.ScheduleEnabled && !entry.AutoSyncEnabled;
+            library.ScheduleEnabled = entry.Enabled && entry.ScheduleEnabled && !entry.AutoSyncEnabled;
             library.ScheduleFrequency = Enum.TryParse<ScheduleFrequency>(entry.ScheduleFrequency, out var frequency)
                 ? frequency
                 : ScheduleFrequency.Daily;
@@ -1363,6 +1418,7 @@ public class LapseController : ControllerBase
             ArrWebhookEnabled = config.ArrWebhookEnabled,
             ArrWebhookToken = config.ArrWebhookToken,
             AutoUpdateEngines = config.AutoUpdateEngines,
+            CountEmbeddedSubtitlesInStatus = config.CountEmbeddedSubtitlesInStatus,
             GoogleTranslateApiKey = config.GoogleTranslateApiKey,
             DeepLApiKey = config.DeepLApiKey,
             LingarrBaseUrl = config.LingarrBaseUrl,
@@ -1373,6 +1429,8 @@ public class LapseController : ControllerBase
             TranslationConfidenceThreshold = config.TranslationConfidenceThreshold,
             TranslationIncludeMetadataHeader = config.TranslationIncludeMetadataHeader,
             TranslationKeepLowConfidenceOriginal = config.TranslationKeepLowConfidenceOriginal,
+            TranslationDefaultTargetLanguage = config.TranslationDefaultTargetLanguage,
+            TranslationDefaultSourceLanguage = config.TranslationDefaultSourceLanguage,
             SubtitleAppearance = config.SubtitleAppearance
         };
 
@@ -1680,6 +1738,7 @@ public class LapseController : ControllerBase
         config.OpenSubtitlesLanguage = Blank(settings.OpenSubtitlesLanguage) ?? "en";
         config.ArrWebhookEnabled = settings.ArrWebhookEnabled;
         config.AutoUpdateEngines = settings.AutoUpdateEngines;
+        config.CountEmbeddedSubtitlesInStatus = settings.CountEmbeddedSubtitlesInStatus;
         config.GoogleTranslateApiKey = Blank(settings.GoogleTranslateApiKey);
         config.DeepLApiKey = Blank(settings.DeepLApiKey);
         config.LingarrBaseUrl = Blank(settings.LingarrBaseUrl);
@@ -1690,6 +1749,8 @@ public class LapseController : ControllerBase
         config.TranslationConfidenceThreshold = Math.Clamp(settings.TranslationConfidenceThreshold, 0, 100);
         config.TranslationIncludeMetadataHeader = settings.TranslationIncludeMetadataHeader;
         config.TranslationKeepLowConfidenceOriginal = settings.TranslationKeepLowConfidenceOriginal;
+        config.TranslationDefaultTargetLanguage = Blank(settings.TranslationDefaultTargetLanguage);
+        config.TranslationDefaultSourceLanguage = Blank(settings.TranslationDefaultSourceLanguage);
 
         if (settings.SubtitleAppearance is not null)
         {
@@ -1814,6 +1875,33 @@ public class LapseController : ControllerBase
                 };
             })
             .ToList();
+    }
+
+    /// <summary>
+    /// Gets what a translation job should start on: the language set in the settings, the
+    /// confidence threshold, and whether the metadata header is wanted. The dialogs used
+    /// to hardcode these, which meant the settings only applied to unattended runs and
+    /// the target language had to be typed in by hand every time, TV remote included.
+    /// </summary>
+    /// <returns>The defaults.</returns>
+    [HttpGet("Lapse/Translate/Defaults")]
+    public ActionResult<TranslationDefaults> GetTranslationDefaults()
+    {
+        var config = Plugin.Instance!.Configuration;
+
+        return new TranslationDefaults
+        {
+            // The automation language is a sensible fallback: someone who set up
+            // automatic translation into Danish is not likely to want something else by
+            // hand.
+            TargetLanguage = string.IsNullOrWhiteSpace(config.TranslationDefaultTargetLanguage)
+                ? config.AutoTranslateLanguage
+                : config.TranslationDefaultTargetLanguage,
+            SourceLanguage = config.TranslationDefaultSourceLanguage,
+            Provider = config.DefaultTranslationProvider.ToString(),
+            ConfidenceThreshold = config.TranslationConfidenceThreshold,
+            IncludeMetadataHeader = config.TranslationIncludeMetadataHeader
+        };
     }
 
     // --------------------------------------------------------------- manual tinkering

--- a/Jellyfin.Plugin.Lapse/Data/MultiSubtitleSyncRequest.cs
+++ b/Jellyfin.Plugin.Lapse/Data/MultiSubtitleSyncRequest.cs
@@ -25,6 +25,17 @@ public class MultiSubtitleSyncRequest
     public string ReferencePath { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the subtitles to line up against the reference, or null/empty for
+    /// every other subtitle on the item. Naming one is how "sync just this track to the
+    /// reference" works, for items where only one of the tracks is off.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Usage",
+        "CA2227:Collection properties should be read only",
+        Justification = "Bound from a request body, and System.Text.Json skips collection properties it can't assign to.")]
+    public List<string>? SubtitlePaths { get; set; }
+
+    /// <summary>
     /// Gets or sets which engine to use, or null for the configured default.
     /// </summary>
     public string? EngineId { get; set; }

--- a/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
+++ b/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
@@ -195,6 +195,12 @@ public class PluginSettings
     public bool AutoUpdateEngines { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether embedded tracks count towards an item
+    /// being synced.
+    /// </summary>
+    public bool CountEmbeddedSubtitlesInStatus { get; set; }
+
+    /// <summary>
     /// Gets or sets the Google Cloud Translation API key.
     /// </summary>
     public string? GoogleTranslateApiKey { get; set; }
@@ -243,6 +249,17 @@ public class PluginSettings
     /// Gets or sets a value indicating whether translated files get a metadata header.
     /// </summary>
     public bool TranslationIncludeMetadataHeader { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the language the translation boxes start on, e.g. "da".
+    /// </summary>
+    public string? TranslationDefaultTargetLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language translations assume the subtitle is in, or null for
+    /// automatic detection.
+    /// </summary>
+    public string? TranslationDefaultSourceLanguage { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether low confidence lines keep their original text.

--- a/Jellyfin.Plugin.Lapse/Data/QueueItemStatus.cs
+++ b/Jellyfin.Plugin.Lapse/Data/QueueItemStatus.cs
@@ -27,5 +27,10 @@ public enum QueueItemStatus
     /// <summary>
     /// The sync itself threw an error the queue couldn't recover from.
     /// </summary>
-    Failed
+    Failed,
+
+    /// <summary>
+    /// Never ran, because someone stopped the job before its turn came up.
+    /// </summary>
+    Cancelled
 }

--- a/Jellyfin.Plugin.Lapse/Data/QueueSnapshot.cs
+++ b/Jellyfin.Plugin.Lapse/Data/QueueSnapshot.cs
@@ -43,6 +43,12 @@ public class QueueSnapshot
     public string? UnitName { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether someone asked for this job to stop and the
+    /// item still running hasn't finished winding down yet.
+    /// </summary>
+    public bool Cancelling { get; set; }
+
+    /// <summary>
     /// Gets or sets the full list of items in the current job, in queue order.
     /// </summary>
     public List<QueueItem> Items { get; init; } = new();

--- a/Jellyfin.Plugin.Lapse/Data/SyncResult.cs
+++ b/Jellyfin.Plugin.Lapse/Data/SyncResult.cs
@@ -75,6 +75,14 @@ public class SyncResult
     public bool LowConfidence { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this run only went through because the
+    /// runner tried again with the engine's force flag, which it does when the first go
+    /// came back saying the subtitle has too few cues to judge. Worth saying out loud:
+    /// nothing checked the answer.
+    /// </summary>
+    public bool Forced { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the result was thrown away and the file on
     /// disk left exactly as it was. Only happens for a low-confidence result under the
     /// "keep original" setting - the run itself still counts as a success, it just

--- a/Jellyfin.Plugin.Lapse/Data/TranslationDefaults.cs
+++ b/Jellyfin.Plugin.Lapse/Data/TranslationDefaults.cs
@@ -1,0 +1,38 @@
+// LAPSE Jellyfin Plugin
+// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Licensed under GPL v3 - see LICENSE for details
+
+namespace Jellyfin.Plugin.Lapse.Data;
+
+/// <summary>
+/// What the translation boxes should start on. Sent to the dialogs so a manual run uses
+/// the same settings an unattended one does.
+/// </summary>
+public class TranslationDefaults
+{
+    /// <summary>
+    /// Gets or sets the language to translate into, or null if none is set.
+    /// </summary>
+    public string? TargetLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language the subtitle is assumed to be in, or null for automatic
+    /// detection.
+    /// </summary>
+    public string? SourceLanguage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the provider to start on.
+    /// </summary>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the confidence threshold, 0-100.
+    /// </summary>
+    public int ConfidenceThreshold { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the metadata comment block is wanted.
+    /// </summary>
+    public bool IncludeMetadataHeader { get; set; }
+}

--- a/Jellyfin.Plugin.Lapse/Engines/EngineRunOptions.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineRunOptions.cs
@@ -52,6 +52,14 @@ public class EngineRunOptions
     public EngineRuntimeInfo Runtime { get; set; } = EngineRuntimeInfo.Unknown;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the engine should sync the file even when
+    /// it doesn't think there's enough of it to judge. The runner sets this for a second
+    /// attempt after a first one refused a very short subtitle, and it's off for the
+    /// normal first run.
+    /// </summary>
+    public bool ForceAnyway { get; set; }
+
+    /// <summary>
     /// Gets or sets this engine's advanced parameters, already merged with the engine's
     /// own defaults.
     /// </summary>

--- a/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
@@ -417,7 +417,8 @@ public class EngineRunner
             }
 
             var ffmpegDirectory = GetFfmpegDirectory();
-            var args = engine.BuildArguments(new EngineRunOptions
+
+            EngineRunOptions BuildOptions(bool forceAnyway) => new()
             {
                 ReferencePath = referencePath,
                 InputPath = enginePathIn,
@@ -427,13 +428,40 @@ public class EngineRunner
                 FfmpegDirectory = ffmpegDirectory,
                 Runtime = runtime,
                 Parameters = ResolveParameters(engine),
-                ConfidenceSigma = Plugin.Instance?.Configuration.ConfidenceSigma ?? LapseEngine.DefaultConfidenceSigma
-            });
+                ConfidenceSigma = Plugin.Instance?.Configuration.ConfidenceSigma ?? LapseEngine.DefaultConfidenceSigma,
+                ForceAnyway = forceAnyway
+            };
+
+            var args = engine.BuildArguments(BuildOptions(false));
 
             var (stdout, stderr, exitCode) = await RunProcessAsync(enginePath, args, ffmpegDirectory, cancellationToken).ConfigureAwait(false);
 
             var result = engine.ParseResult(stdout, stderr, exitCode, mode, penalty);
             result.EngineId = engine.Descriptor.Id;
+
+            // A short subtitle - forced signs, a few lines of foreign dialogue - has too
+            // few cues for the engine to be sure of its answer, and it stops rather than
+            // guessing. The file isn't wrong, there just isn't much of it, and the engine
+            // says as much and points at its own --force. Someone pressed Sync on this,
+            // so take it up rather than handing back a refusal they can do nothing about.
+            if (!result.Success && IsTooFewCues(result.Error))
+            {
+                _logger.LogInformation(
+                    "{Engine} says {Subtitle} is too short to judge, trying again with force",
+                    engine.Descriptor.DisplayName,
+                    subtitlePath);
+
+                var forcedArgs = engine.BuildArguments(BuildOptions(true));
+
+                if (!forcedArgs.SequenceEqual(args))
+                {
+                    (stdout, stderr, exitCode) = await RunProcessAsync(enginePath, forcedArgs, ffmpegDirectory, cancellationToken).ConfigureAwait(false);
+
+                    result = engine.ParseResult(stdout, stderr, exitCode, mode, penalty);
+                    result.EngineId = engine.Descriptor.Id;
+                    result.Forced = result.Success;
+                }
+            }
 
             if (!result.Success)
             {
@@ -683,9 +711,51 @@ public class EngineRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Waiting stops on cancellation, the engine doesn't. Without this a stopped
+            // job leaves a decoder running over a whole film in the background.
+            KillQuietly(process);
+            throw;
+        }
 
         return (stdoutBuilder.ToString(), stderrBuilder.ToString(), process.ExitCode);
+    }
+
+    // The engine's own words for "there isn't enough of this file to work with", which it
+    // ends with a pointer at --force. Matched on the text because that is all a failed
+    // run gives us: there's no separate exit code for it.
+    private static bool IsTooFewCues(string? error)
+    {
+        if (string.IsNullOrEmpty(error))
+        {
+            return false;
+        }
+
+        return error.Contains("--force", StringComparison.OrdinalIgnoreCase)
+            && (error.Contains("not enough", StringComparison.OrdinalIgnoreCase)
+                || error.Contains("too few", StringComparison.OrdinalIgnoreCase)
+                || error.Contains("cues", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void KillQuietly(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                // The engines start ffmpeg of their own, so the whole tree goes.
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+        {
+            _logger.LogDebug(ex, "Could not stop the engine process after the job was cancelled");
+        }
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Lapse/Engines/LapseEngine.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/LapseEngine.cs
@@ -129,11 +129,19 @@ public partial class LapseEngine : IEngine
 
         AddNumber(args, runtime, values, "audioTrack", "--audio-track");
         AddNumber(args, runtime, values, "subTrack", "--sub-track");
+        AddNumber(args, runtime, values, "fps", "--fps");
 
         AddSwitch(args, runtime, values, "noEmbedded", "--no-embedded");
         AddSwitch(args, runtime, values, "fullScan", "--full-scan");
         AddSwitch(args, runtime, values, "noCache", "--no-cache");
         AddSwitch(args, runtime, values, "force", "--force");
+
+        // The runner asks for this on a second attempt, after the engine turned a very
+        // short subtitle away for having too few cues to be sure about.
+        if (options.ForceAnyway && !values.GetBool("force") && runtime.HasFlag("--force"))
+        {
+            args.Add("--force");
+        }
 
         return args;
     }
@@ -258,6 +266,18 @@ public partial class LapseEngine : IEngine
             Flag = "--sub-track",
             Kind = EngineParameterKind.Number,
             Minimum = 0,
+            BlankMeansUnset = true
+        });
+
+        descriptor.Parameters.Add(new EngineParameter
+        {
+            Key = "fps",
+            Label = "Frame rate for MicroDVD subtitles",
+            Description = "MicroDVD .sub files count frames rather than time, so they need a frame rate. The engine reads it from the video, or from the file's own header when there is one, and only needs telling when neither is there. Blank leaves it to work that out.",
+            Flag = "--fps",
+            Kind = EngineParameterKind.Number,
+            Minimum = 10,
+            Maximum = 120,
             BlankMeansUnset = true
         });
 

--- a/Jellyfin.Plugin.Lapse/Services/SubtitleTextFile.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SubtitleTextFile.cs
@@ -100,14 +100,27 @@ public class SubtitleTextFile
     public async Task SaveAsync(string path, IReadOnlyList<string>? headerLines, CancellationToken cancellationToken = default)
     {
         var output = new List<string>();
+        var body = _lines;
 
-        if (headerLines is { Count: > 0 })
+        if (headerLines is { Count: > 0 } && SupportsComments)
         {
+            // A WebVTT file has to start with the WEBVTT line and nothing else, so the
+            // NOTE block goes underneath it rather than above. Anything else takes the
+            // header at the very top.
+            var signature = _lines.FindIndex(line => line.Trim().StartsWith("WEBVTT", StringComparison.OrdinalIgnoreCase));
+
+            if (signature >= 0)
+            {
+                output.AddRange(_lines.Take(signature + 1));
+                output.Add(string.Empty);
+                body = _lines.Skip(signature + 1).SkipWhile(string.IsNullOrWhiteSpace).ToList();
+            }
+
             output.AddRange(headerLines.Select(CommentFor));
             output.Add(string.Empty);
         }
 
-        output.AddRange(_lines);
+        output.AddRange(body);
 
         await File.WriteAllLinesAsync(path, output, SubtitleEncoding.Utf8NoBom, cancellationToken).ConfigureAwait(false);
     }
@@ -145,11 +158,19 @@ public class SubtitleTextFile
         return Path.Combine(directory, $"{stem}.{targetLanguage}.translated{extension}");
     }
 
+    /// <summary>
+    /// Gets a value indicating whether this format has a comment syntax to put a header
+    /// in. SRT has none: the NOTE block that used to be written there is not a numbered
+    /// cue, and players that parse strictly - which is most of them once the file leaves
+    /// Jellyfin - either drop the first subtitle or reject the file outright. So the
+    /// header is a WebVTT and ASS/SSA thing, and asking for one on an SRT quietly gets a
+    /// clean file instead of a broken one.
+    /// </summary>
+    public bool SupportsComments => Extension is ".ass" or ".ssa" or ".vtt" or ".webvtt";
+
     private string CommentFor(string text)
     {
-        // ASS/SSA use ; for comments, WebVTT uses NOTE, and SRT has no comment syntax at
-        // all - a NOTE block at the top is ignored by every player worth worrying about
-        // because it isn't a numbered cue.
+        // ASS/SSA use ; for comments, WebVTT uses NOTE.
         return Extension is ".ass" or ".ssa" ? "; " + text : "NOTE " + text;
     }
 

--- a/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
@@ -55,6 +55,12 @@ public class SyncQueueManager : IDisposable
     private string? _unitName;
     private string? _referenceKey;
 
+    // Cancelled with Cancel(), replaced when the next job starts. Everything the queue
+    // runs takes this token, so stopping a job stops the engine that is running right
+    // now as well as everything still waiting in line.
+    private CancellationTokenSource _jobCancellation = new();
+    private bool _cancelRequested;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SyncQueueManager"/> class.
     /// </summary>
@@ -140,7 +146,8 @@ public class SyncQueueManager : IDisposable
             {
                 Running = current is not null || _pending.Count > 0,
                 Total = _items.Count,
-                Completed = _items.Count(i => i.Status is QueueItemStatus.Done or QueueItemStatus.Failed),
+                Completed = _items.Count(i => i.Status is QueueItemStatus.Done or QueueItemStatus.Failed or QueueItemStatus.Cancelled),
+                Cancelling = _cancelRequested && current is not null,
                 CurrentItemName = current?.Name,
                 JobName = _jobName,
                 UnitName = _unitName,
@@ -212,6 +219,7 @@ public class SyncQueueManager : IDisposable
                 _referenceKey = null;
                 _jobName = null;
                 _unitName = "item";
+                ResetCancellation();
             }
 
             if (!_queuedIds.Add(item.Id))
@@ -224,6 +232,46 @@ public class SyncQueueManager : IDisposable
         }
 
         EnsureWorkerRunning();
+    }
+
+    /// <summary>
+    /// Stops the job that's running: drops everything still waiting and cancels the item
+    /// being synced right now, which kills the engine process with it. Files already
+    /// written stay written - this stops the run, it doesn't undo it.
+    /// </summary>
+    /// <returns>How many queued items were dropped, or null if nothing was running.</returns>
+    public int? Cancel()
+    {
+        CancellationTokenSource? cancellation = null;
+        int dropped;
+
+        lock (_lock)
+        {
+            var running = _items.Any(i => i.Status == QueueItemStatus.Running);
+            if (_pending.Count == 0 && !running)
+            {
+                return null;
+            }
+
+            dropped = _pending.Count;
+            _pending.Clear();
+            _queuedIds.Clear();
+            _cancelRequested = true;
+
+            foreach (var item in _items.Where(i => i.Status == QueueItemStatus.Queued))
+            {
+                item.Status = QueueItemStatus.Cancelled;
+            }
+
+            cancellation = _jobCancellation;
+        }
+
+        _logger.LogInformation("Sync job stopped by hand, {Dropped} queued items dropped", dropped);
+
+        // Outside the lock: cancelling runs the continuations of whatever is waiting on
+        // this token, and those want the lock themselves.
+        cancellation.Cancel();
+        return dropped;
     }
 
     /// <summary>
@@ -254,8 +302,14 @@ public class SyncQueueManager : IDisposable
                 _referenceKey = null;
                 _jobName = "Scheduled sync";
                 _unitName = "item";
+                ResetCancellation();
             }
         }
+
+        // A scheduled run gets the same Stop button as a bulk one, so it listens to both
+        // Jellyfin's own token and the queue's.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, JobToken);
+        cancellationToken = linked.Token;
 
         for (var i = 0; i < items.Count; i++)
         {
@@ -351,6 +405,7 @@ public class SyncQueueManager : IDisposable
             _jobName = jobName;
             _unitName = unitName ?? "item";
             _referenceKey = referenceKey;
+            ResetCancellation();
 
             foreach (var item in items)
             {
@@ -418,21 +473,67 @@ public class SyncQueueManager : IDisposable
         if (disposing)
         {
             _runGate.Dispose();
+            _jobCancellation.Dispose();
         }
     }
 
     private async Task<bool> ProcessOneAsync(Guid itemId, CancellationToken cancellationToken)
     {
-        await _runGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // Whatever the caller handed us, plus the Stop button.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, JobToken);
+        var token = linked.Token;
 
         try
         {
-            return await SyncOneAsync(itemId, cancellationToken).ConfigureAwait(false);
+            await _runGate.WaitAsync(token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            SetItemStatus(itemId, QueueItemStatus.Cancelled);
+            return false;
+        }
+
+        try
+        {
+            return await SyncOneAsync(itemId, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Stopped part way through. The engine writes to a temporary file and only
+            // moves it into place at the end, so the subtitle on disk is untouched.
+            SetItemStatus(itemId, QueueItemStatus.Cancelled);
+            SaveRecord(itemId, MovieSyncStatus.Pending, "Stopped before this item finished");
+            return false;
         }
         finally
         {
             _runGate.Release();
         }
+    }
+
+    // The token every item in the current job runs under.
+    private CancellationToken JobToken
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _jobCancellation.Token;
+            }
+        }
+    }
+
+    // Called under _lock whenever a fresh job starts, so a Stop from the last one doesn't
+    // kill the new one on its way out of the gate.
+    private void ResetCancellation()
+    {
+        if (_jobCancellation.IsCancellationRequested)
+        {
+            _jobCancellation.Dispose();
+            _jobCancellation = new CancellationTokenSource();
+        }
+
+        _cancelRequested = false;
     }
 
     private async Task<bool> SyncOneAsync(Guid itemId, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.Lapse/Services/Translation/DeepLTranslationProvider.cs
+++ b/Jellyfin.Plugin.Lapse/Services/Translation/DeepLTranslationProvider.cs
@@ -26,6 +26,14 @@ public class DeepLTranslationProvider : ITranslationProvider
     // DeepL takes up to 50 text parameters per request.
     private const int BatchSize = 50;
 
+    // DeepL asks callers to back off and try again rather than treating a 429 as a
+    // failure: https://developers.deepl.com/docs/best-practices/error-handling.
+    // A whole film is a fair few batches, so hitting the limit on a busy key is normal
+    // and shouldn't throw away the work already done.
+    private const int MaxAttempts = 5;
+    private const int FirstRetryDelayMs = 1000;
+    private const int MaxRetryDelayMs = 30000;
+
     private const string FreeEndpoint = "https://api-free.deepl.com/v2/translate";
     private const string ProEndpoint = "https://api.deepl.com/v2/translate";
 
@@ -108,14 +116,8 @@ public class DeepLTranslationProvider : ITranslationProvider
                 payload["source_lang"] = sourceLanguage.ToUpperInvariant();
             }
 
-            using var request = new HttpRequestMessage(HttpMethod.Post, url)
-            {
-                Content = JsonContent.Create(payload)
-            };
-
-            request.Headers.TryAddWithoutValidation("Authorization", "DeepL-Auth-Key " + apiKey);
-
-            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using var response = await SendWithRetriesAsync(client, url, apiKey, payload, cancellationToken)
+                .ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -124,7 +126,7 @@ public class DeepLTranslationProvider : ITranslationProvider
                     CultureInfo.InvariantCulture,
                     "DeepL returned {0}: {1}",
                     (int)response.StatusCode,
-                    Shorten(body)));
+                    Describe(response.StatusCode, Shorten(body))));
             }
 
             using var document = await response.Content
@@ -135,6 +137,85 @@ public class DeepLTranslationProvider : ITranslationProvider
         }
 
         return results;
+    }
+
+    // Sends one batch, backing off and trying again when DeepL says it's too busy. 429 is
+    // the rate limit and 5xx is a wobble at their end; both are documented as retryable.
+    // Anything else comes straight back for the caller to report.
+    private async Task<HttpResponseMessage> SendWithRetriesAsync(
+        HttpClient client,
+        string url,
+        string apiKey,
+        Dictionary<string, object> payload,
+        CancellationToken cancellationToken)
+    {
+        var delayMs = FirstRetryDelayMs;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(payload)
+            };
+
+            request.Headers.TryAddWithoutValidation("Authorization", "DeepL-Auth-Key " + apiKey);
+
+            var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (!IsRetryable(response.StatusCode) || attempt >= MaxAttempts)
+            {
+                return response;
+            }
+
+            // DeepL can say how long to wait. When it does, that beats guessing.
+            var wait = response.Headers.RetryAfter?.Delta
+                ?? (response.Headers.RetryAfter?.Date is { } date ? date - DateTimeOffset.UtcNow : (TimeSpan?)null)
+                ?? TimeSpan.FromMilliseconds(delayMs);
+
+            if (wait < TimeSpan.Zero)
+            {
+                wait = TimeSpan.FromMilliseconds(delayMs);
+            }
+
+            if (wait > TimeSpan.FromMilliseconds(MaxRetryDelayMs))
+            {
+                wait = TimeSpan.FromMilliseconds(MaxRetryDelayMs);
+            }
+
+            _logger.LogInformation(
+                "DeepL returned {Status}, waiting {Seconds:0.#}s and trying again (attempt {Attempt} of {Max})",
+                (int)response.StatusCode,
+                wait.TotalSeconds,
+                attempt,
+                MaxAttempts);
+
+            response.Dispose();
+
+            await Task.Delay(wait, cancellationToken).ConfigureAwait(false);
+
+            // Doubling, so a key that is properly busy isn't hammered on the way out.
+            delayMs = Math.Min(delayMs * 2, MaxRetryDelayMs);
+        }
+    }
+
+    private static bool IsRetryable(System.Net.HttpStatusCode status)
+    {
+        return status == System.Net.HttpStatusCode.TooManyRequests || (int)status >= 500;
+    }
+
+    // The status codes worth explaining rather than leaving as a bare number.
+    private static string Describe(System.Net.HttpStatusCode status, string body)
+    {
+        return status switch
+        {
+            System.Net.HttpStatusCode.TooManyRequests =>
+                "too many requests, and it was still busy after several retries. Try again later, or use a different provider for now. " + body,
+            System.Net.HttpStatusCode.Forbidden =>
+                "the API key was rejected. Check it under Translation in the LAPSE dashboard. " + body,
+            (System.Net.HttpStatusCode)456 =>
+                "the character quota on that DeepL key is used up for this billing period. " + body,
+            _ => body
+        };
     }
 
     private IEnumerable<TranslatedLine> ReadTranslations(JsonDocument? document, int expected)

--- a/Jellyfin.Plugin.Lapse/Services/Translation/LingarrTranslationProvider.cs
+++ b/Jellyfin.Plugin.Lapse/Services/Translation/LingarrTranslationProvider.cs
@@ -152,6 +152,35 @@ public class LingarrTranslationProvider : ITranslationProvider
             }
         }
 
+        // Some builds wrap the line in an object instead. Take the text out of it rather
+        // than dropping the whole JSON document into the subtitle, which is what
+        // returning the body as-is would do.
+        if (raw.StartsWith('{'))
+        {
+            try
+            {
+                using var document = System.Text.Json.JsonDocument.Parse(raw);
+
+                foreach (var name in new[] { "translatedText", "translation", "text", "line", "result" })
+                {
+                    if (document.RootElement.TryGetProperty(name, out var value)
+                        && value.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        return value.GetString();
+                    }
+                }
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                _logger.LogDebug(ex, "Lingarr returned something that didn't parse as JSON: {Raw}", Shorten(raw));
+            }
+
+            // An object we can't read is not a translation, and a subtitle line is a
+            // worse place for it than the log.
+            _logger.LogWarning("Lingarr answered with JSON that has no line in it: {Raw}", Shorten(raw));
+            return null;
+        }
+
         return raw;
     }
 

--- a/Jellyfin.Plugin.Lapse/Services/Translation/TranslationService.cs
+++ b/Jellyfin.Plugin.Lapse/Services/Translation/TranslationService.cs
@@ -105,11 +105,16 @@ public class TranslationService
             return result;
         }
 
+        // "auto" is what the From box says when it's empty, and people type it. Half the
+        // providers take it as a language code and the other half reject it, so it means
+        // "nobody said" here and each provider does whatever it does with that.
+        var sourceLanguage = NormalizeSource(request.SourceLanguage);
+
         IReadOnlyList<TranslatedLine> translations;
         try
         {
             translations = await provider
-                .TranslateAsync(lines, request.SourceLanguage, request.TargetLanguage, cancellationToken)
+                .TranslateAsync(lines, sourceLanguage, request.TargetLanguage, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or TaskCanceledException)
@@ -129,7 +134,7 @@ public class TranslationService
         for (var i = 0; i < lines.Count; i++)
         {
             var translated = i < translations.Count ? translations[i] : new TranslatedLine();
-            var score = Score(lines[i], translated, request.SourceLanguage);
+            var score = Score(lines[i], translated, sourceLanguage);
             scores.Add(score);
 
             if (translated.Text is null)
@@ -158,7 +163,7 @@ public class TranslationService
         file.ApplyTranslations(replacements);
 
         var outputPath = SubtitleTextFile.BuildOutputPath(subtitlePath, request.TargetLanguage);
-        var header = includeHeader ? BuildHeader(provider, request, result, threshold) : null;
+        var header = includeHeader ? BuildHeader(provider, sourceLanguage, request, result, threshold) : null;
 
         try
         {
@@ -186,8 +191,26 @@ public class TranslationService
         return result;
     }
 
+    // Empty, "auto", "automatic" and "detect" all mean the same thing: let the provider
+    // work it out.
+    private static string? NormalizeSource(string? sourceLanguage)
+    {
+        var trimmed = sourceLanguage?.Trim();
+
+        if (string.IsNullOrEmpty(trimmed)
+            || trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("automatic", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("detect", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return trimmed;
+    }
+
     private static IReadOnlyList<string> BuildHeader(
         ITranslationProvider provider,
+        string? sourceLanguage,
         TranslationRequest request,
         TranslationResult result,
         int threshold)
@@ -197,7 +220,7 @@ public class TranslationService
             "Translated by the LAPSE Jellyfin plugin",
             "Provider: " + provider.DisplayName,
             "Date: " + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture),
-            "Source language: " + (string.IsNullOrWhiteSpace(request.SourceLanguage) ? "auto-detected" : request.SourceLanguage),
+            "Source language: " + (sourceLanguage ?? "auto-detected"),
             "Target language: " + request.TargetLanguage,
             string.Format(
                 CultureInfo.InvariantCulture,

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ Requires Jellyfin 10.11.11 or newer.
 Every film, episode and loose video gets these entries in its three dot menu:
 
 - **Sync Subtitles** - the main one. Pick a subtitle if there's more than one, press Sync, done. Advanced options let you pick a different mode, output format, translate at the same time, or nudge the timing by hand.
-- **Sync All Subtitles to Reference** - for items with several subtitle tracks where one is already correct. Lines every other track up against it. Skips the audio entirely, so it's fast and usually more accurate than syncing each track on its own.
+- **Sync Subtitles to Reference** - for items with several subtitle tracks where one is already correct. Lines every other track up against it, or just the one track you pick. Skips the audio entirely, so it's fast and usually more accurate than syncing each track on its own.
 - **Shift Subtitles** - manual millisecond nudging with a live preview, for when a sync is close but not quite right. Works even without an engine installed.
 - **Convert Subtitles** - writes a subtitle out as `.srt`, `.vtt`, `.ass` or `.ssa`, leaving the original alone unless you say otherwise. Useful for players that only take one format, or for formats no engine can sync directly (LAPSE converts those on its own when needed, so this is rarely something you have to do by hand).
-- **Translate** - a separate job from syncing that never touches the original file. Providers include MyMemory (no setup needed), self-hosted LibreTranslate and Lingarr, and DeepL or Google Cloud with a key.
+- **Translate** (experimental) - a separate job from syncing that never touches the original file. Providers include MyMemory (no setup needed), self-hosted LibreTranslate and Lingarr, and DeepL or Google Cloud with a key. Set a default language under Translation and the dialogs start on it, so nothing has to be typed on a TV remote.
 
 Elsewhere in the dashboard:
 
-- **Sync status, Bulk sync, Subtitle to subtitle** - a searchable list of every syncable item, a page to sync a whole library or folder at once, and a way to line up two subtitle files directly without a library item involved.
+- **Sync status, Bulk sync, Subtitle to subtitle** - a searchable list of every syncable item, a page to sync a whole library or folder at once, and a way to line up two subtitle files directly without a library item involved. An item counts as synced once its subtitle files have been synced; tracks still inside the video file are left out of that unless you ask for them, since nothing automatic touches those.
+- **Stop** - any running job, whether it is a whole library, a series or a scheduled run, can be stopped from the progress strip on the dashboard or from the progress toast wherever it was started.
 - **Automation** - libraries can pick up new items automatically or sync on a schedule, and unattended runs can sync, convert, translate, or react to a Radarr/Sonarr import webhook. Everything here is off by default; pressing a button yourself always works regardless.
 - **Access control** - the menu entries above are admin only by default, but can be opened up to specific users or everyone signed in.
 - **Undo** - every recent sync can be reversed with one press, whether that means restoring a backup or deleting the file the run added.


### PR DESCRIPTION
…on fixes

- Any running sync job (bulk, series, scheduled) can now be stopped from the dashboard or the progress toast, killing the engine process rather than leaving it running.
- Sync Subtitles to Reference can now target one chosen track instead of always syncing every other subtitle. Menu label dropped "All" to match.
- Embedded subtitle tracks no longer count towards an item's sync status by default, since nothing automatic ever touches them; a new setting brings them back in for anyone syncing embedded tracks by hand.
- DeepL translation retries on 429/5xx with backoff and Retry-After support.
- Translation metadata header is skipped for .srt (no comment syntax) and placed after the WEBVTT line for .vtt instead of breaking either format.
- Advanced sync dialog reworked so actions sit in one row at the bottom, and a configurable default source/target language fills the Translate boxes in rather than starting empty.
- LAPSE engine: a "too few cues" refusal is retried once with --force, and a new --fps parameter is exposed for MicroDVD subtitles.
- Disabling a library now automatically turns off its "new items" and "schedule" sync, both in the UI and on save, instead of leaving them checked-and-inert until the library is turned back on.
- Translation is marked experimental in the dashboard.