### PR TITLE
Skip rewriting subtitles that are already in sync

### DIFF
--- a/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Lapse/Configuration/PluginConfiguration.cs
@@ -77,6 +77,22 @@ public class PluginConfiguration : BasePluginConfiguration
     public LowConfidenceAction LowConfidenceAction { get; set; } = LowConfidenceAction.Sidecar;
 
     /// <summary>
+    /// Gets or sets a value indicating whether a subtitle the engine barely moved is left
+    /// exactly as it was. A bulk run over a whole library goes through subtitles that were
+    /// already fine, and rewriting those - new file, new backup, new timestamps - for a
+    /// shift nobody can see is churn at best. On by default.
+    /// </summary>
+    public bool SkipAlreadyInSync { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how small the engine's answer has to be, in milliseconds, before
+    /// <see cref="SkipAlreadyInSync"/> treats the subtitle as already correct. 100ms is
+    /// under what anyone notices while reading along, and well under the drift that makes
+    /// someone go looking for a sync button in the first place.
+    /// </summary>
+    public int AlreadyInSyncToleranceMs { get; set; } = 100;
+
+    /// <summary>
     /// Gets or sets how far LAPSE's answer has to stand out from the alternatives before
     /// it counts as confident, in standard deviations. This is passed straight to the
     /// engine as --confidence, and the default is the engine's own internal default

--- a/Jellyfin.Plugin.Lapse/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lapse/Configuration/configPage.html
@@ -311,6 +311,30 @@
                             page instead.
                         </div>
 
+                        <h3 class="lapseSubHeading">Subtitles that are already right</h3>
+                        <label class="emby-checkbox-label lapseStackedCheck">
+                            <input id="lapseSkipAlreadyInSync" type="checkbox" is="emby-checkbox" />
+                            <span>Leave a subtitle alone when it is already in sync</span>
+                        </label>
+                        <div class="fieldDescription lapseTightNote">
+                            A run over a whole library goes through plenty of subtitles that were
+                            fine to begin with. With this on, an answer smaller than the tolerance
+                            below counts as no change: nothing is rewritten, no backup is taken,
+                            and the subtitle still counts as synced. Stretched and split results
+                            are always written, however small the shift, because those change the
+                            timing across the whole file rather than moving it as one piece.
+                        </div>
+                        <div class="inputContainer" id="lapseAlreadyInSyncToleranceRow">
+                            <label class="inputLabel inputLabelUnfocused" for="lapseAlreadyInSyncTolerance">
+                                Tolerance: <span id="lapseAlreadyInSyncToleranceValue"></span>
+                            </label>
+                            <input type="range" id="lapseAlreadyInSyncTolerance" min="0" max="1000" step="10" class="lapseRange" />
+                            <div class="fieldDescription">
+                                Anything at or under this counts as already in sync. 100ms is under
+                                what anyone notices while reading along.
+                            </div>
+                        </div>
+
                         <h3 class="lapseSubHeading">Confidence</h3>
                         <div class="fieldDescription lapseTightNote">
                             <strong>LAPSE only.</strong> LAPSE measures how far its answer stands out from

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.css
@@ -325,6 +325,12 @@
     opacity: .5;
 }
 
+/* A control that is still worth reading but cannot be changed until the box above it
+   is ticked. */
+.lapseDimmed {
+    opacity: .5;
+}
+
 .lapseLibraryMain {
     display: flex;
     align-items: center;

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-dashboard.js
@@ -1822,6 +1822,13 @@
             return;
         }
 
+        if (result.AlreadyInSync) {
+            Dashboard.alert(name + ': already in sync, so the file was left exactly as it was.\n\n' +
+                'The engine would have moved it ' + (result.OffsetMs || 0) + 'ms, which is inside the ' +
+                'tolerance set under File output.');
+            return;
+        }
+
         if (result.Skipped) {
             Dashboard.alert(name + ': left the original alone (' + describeResult(result) + ').\n\n' +
                 'The engine was not confident enough, and File output is set to keep the original ' +
@@ -2496,6 +2503,10 @@
             Dashboard.hideLoadingMsg();
             if (!result.Success) {
                 Dashboard.alert('Sync failed: ' + result.Error);
+            } else if (result.AlreadyInSync) {
+                Dashboard.alert('Already in sync, so the input was left exactly as it was. The engine ' +
+                    'would have moved it ' + (result.OffsetMs || 0) + 'ms, which is inside the tolerance ' +
+                    'set under File output.');
             } else if (result.Skipped) {
                 Dashboard.alert('Left the input alone (' + describeResult(result) +
                     '), which is under the confidence threshold.\n\n' + FORCE_HINT);
@@ -2604,6 +2615,18 @@
         }
 
         view.querySelector('#lapseConfidenceSigmaNote').textContent = note;
+    }
+
+    function updateAlreadyInSyncNote(view) {
+        var on = view.querySelector('#lapseSkipAlreadyInSync').checked;
+        var row = view.querySelector('#lapseAlreadyInSyncToleranceRow');
+        var value = parseInt(view.querySelector('#lapseAlreadyInSyncTolerance').value, 10) || 0;
+
+        // Zero still works - it means only an exact zero offset is left alone - so the
+        // slider stays readable rather than being hidden when the box is unticked.
+        row.classList.toggle('lapseDimmed', !on);
+        view.querySelector('#lapseAlreadyInSyncTolerance').disabled = !on;
+        view.querySelector('#lapseAlreadyInSyncToleranceValue').textContent = value + 'ms';
     }
 
     // No "Recommended" badges in here. Which format you want depends on what is going to
@@ -2809,6 +2832,11 @@
         view.querySelector('#lapseSidecarSuffix').value = currentSettings.SidecarSuffix || '.shifted';
         view.querySelector('#lapseConfidenceSigma').value = currentSettings.ConfidenceSigma || 8;
         updateConfidenceNote(view);
+
+        view.querySelector('#lapseSkipAlreadyInSync').checked = currentSettings.SkipAlreadyInSync !== false;
+        view.querySelector('#lapseAlreadyInSyncTolerance').value =
+            currentSettings.AlreadyInSyncToleranceMs == null ? 100 : currentSettings.AlreadyInSyncToleranceMs;
+        updateAlreadyInSyncNote(view);
 
         view.querySelector('#lapseConfidence').value = currentSettings.TranslationConfidenceThreshold;
         view.querySelector('#lapseKeepLowConfidence').checked = !!currentSettings.TranslationKeepLowConfidenceOriginal;
@@ -3067,6 +3095,8 @@
             SidecarSuffix: view.querySelector('#lapseSidecarSuffix').value,
             LowConfidenceAction: selectedRadio(view, 'lapseLowConfidence', 'Sidecar'),
             ConfidenceSigma: parseFloat(view.querySelector('#lapseConfidenceSigma').value) || 8,
+            SkipAlreadyInSync: view.querySelector('#lapseSkipAlreadyInSync').checked,
+            AlreadyInSyncToleranceMs: parseInt(view.querySelector('#lapseAlreadyInSyncTolerance').value, 10) || 0,
             AutoUpdateEngines: view.querySelector('#lapseAutoUpdateEngines').checked,
             CountEmbeddedSubtitlesInStatus: view.querySelector('#lapseCountEmbedded').checked,
             SubToSubPlacement: view.querySelector('#lapseSubToSubPlacement').value,
@@ -3330,6 +3360,12 @@
         });
         view.querySelector('#lapseConfidenceSigma').addEventListener('input', function () {
             updateConfidenceNote(view);
+        });
+        view.querySelector('#lapseAlreadyInSyncTolerance').addEventListener('input', function () {
+            updateAlreadyInSyncNote(view);
+        });
+        view.querySelector('#lapseSkipAlreadyInSync').addEventListener('change', function () {
+            updateAlreadyInSyncNote(view);
         });
         view.querySelector('#btnSaveConversion').addEventListener('click', function () {
             saveSettings(view, 'Conversion settings saved.');

--- a/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
+++ b/Jellyfin.Plugin.Lapse/Configuration/lapse-inject.js
@@ -652,6 +652,11 @@
             return 'Sync failed: ' + result.Error;
         }
 
+        if (result.AlreadyInSync) {
+            return 'Already in sync, so nothing was changed. The engine would have moved it ' +
+                (result.OffsetMs || 0) + 'ms, which is inside the tolerance set under File output.';
+        }
+
         if (result.Skipped) {
             return 'Left the original alone - ' + describeResult(result) +
                 ', which is under the confidence threshold. Change what happens then under ' +

--- a/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
+++ b/Jellyfin.Plugin.Lapse/Controllers/LapseController.cs
@@ -548,7 +548,10 @@ public class LapseController : ControllerBase
             ResolveRecordStatus(result),
             result.Success && result.Skipped ? SyncQueueManager.DescribeSkip(result) : result.Error,
             result,
-            result.Success && !result.Skipped ? new[] { subtitlePath } : null);
+
+            // Nothing was written for an already-in-sync subtitle, but the file on disk is
+            // correct, so it counts towards the item being synced just the same.
+            result.Success && (!result.Skipped || result.AlreadyInSync) ? new[] { subtitlePath } : null);
 
         return result;
     }
@@ -562,7 +565,10 @@ public class LapseController : ControllerBase
             return MovieSyncStatus.Failed;
         }
 
-        return result.Skipped ? MovieSyncStatus.Pending : MovieSyncStatus.Synced;
+        // A subtitle that was left alone because it was already right is synced. Only the
+        // low-confidence kind of skip goes back to pending, since that one leaves a file
+        // nobody has checked.
+        return result.Skipped && !result.AlreadyInSync ? MovieSyncStatus.Pending : MovieSyncStatus.Synced;
     }
 
     /// <summary>
@@ -691,7 +697,7 @@ public class LapseController : ControllerBase
         // The reference itself is correct by definition - that's why it was picked - so it
         // counts as synced alongside everything that was lined up against it.
         var writtenPaths = result.Results
-            .Where(o => o.Result is { Success: true, Skipped: false })
+            .Where(o => o.Result is { Success: true, Skipped: false } or { Success: true, AlreadyInSync: true })
             .Select(o => o.Path)
             .Append(referencePath)
             .ToList();
@@ -1392,6 +1398,8 @@ public class LapseController : ControllerBase
             OutputMode = config.OutputMode,
             SidecarSuffix = config.SidecarSuffix,
             LowConfidenceAction = config.LowConfidenceAction,
+            SkipAlreadyInSync = config.SkipAlreadyInSync,
+            AlreadyInSyncToleranceMs = config.AlreadyInSyncToleranceMs,
             ConfidenceSigma = config.ConfidenceSigma,
             SubToSubPlacement = config.SubToSubPlacement,
             SubToSubCustomFolder = config.SubToSubCustomFolder,
@@ -1697,6 +1705,11 @@ public class LapseController : ControllerBase
         config.OutputMode = settings.OutputMode;
         config.SidecarSuffix = string.IsNullOrWhiteSpace(settings.SidecarSuffix) ? ".shifted" : settings.SidecarSuffix.Trim();
         config.LowConfidenceAction = settings.LowConfidenceAction;
+        config.SkipAlreadyInSync = settings.SkipAlreadyInSync;
+
+        // A negative tolerance would mean nothing is ever close enough, and anything past
+        // a few seconds stops being "already fine" and starts being a sync nobody did.
+        config.AlreadyInSyncToleranceMs = Math.Clamp(settings.AlreadyInSyncToleranceMs, 0, 5000);
 
         // The engine rejects anything at or below zero, and a runaway value would just mean
         // nothing is ever confident enough to write.

--- a/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
+++ b/Jellyfin.Plugin.Lapse/Data/PluginSettings.cs
@@ -80,6 +80,17 @@ public class PluginSettings
     public LowConfidenceAction LowConfidenceAction { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether a subtitle the engine barely moved is left
+    /// alone instead of being rewritten.
+    /// </summary>
+    public bool SkipAlreadyInSync { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how small a shift counts as already in sync, in milliseconds.
+    /// </summary>
+    public int AlreadyInSyncToleranceMs { get; set; } = 100;
+
+    /// <summary>
     /// Gets or sets how far LAPSE's answer has to stand out before it counts as confident,
     /// in standard deviations. Passed straight to the engine as --confidence.
     /// </summary>

--- a/Jellyfin.Plugin.Lapse/Data/SyncResult.cs
+++ b/Jellyfin.Plugin.Lapse/Data/SyncResult.cs
@@ -84,11 +84,19 @@ public class SyncResult
 
     /// <summary>
     /// Gets or sets a value indicating whether the result was thrown away and the file on
-    /// disk left exactly as it was. Only happens for a low-confidence result under the
-    /// "keep original" setting - the run itself still counts as a success, it just
-    /// deliberately didn't write anything.
+    /// disk left exactly as it was. Happens for a low-confidence result under the "keep
+    /// original" setting, and for a subtitle that turned out to already be in sync - the
+    /// run itself still counts as a success, it just deliberately didn't write anything.
     /// </summary>
     public bool Skipped { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the engine's answer was small enough to
+    /// count as no change at all, so the file was left alone. Unlike the low-confidence
+    /// kind of <see cref="Skipped"/>, this one means the subtitle is right: it counts as
+    /// synced everywhere the plugin keeps track of what's been done.
+    /// </summary>
+    public bool AlreadyInSync { get; set; }
 
     /// <summary>
     /// Gets or sets the subtitle that was read. Recorded so the history can tell a run

--- a/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
+++ b/Jellyfin.Plugin.Lapse/Engines/EngineRunner.cs
@@ -524,6 +524,28 @@ public class EngineRunner
                 }
             }
 
+            // A subtitle that was already right is the common case in a bulk run, and the
+            // engine reporting "move it 12ms" on one is not a reason to replace the file.
+            // Only for a run that would otherwise have rewritten the subtitle in place:
+            // an explicit destination or a format change means the caller asked for a new
+            // file to exist, and that has to happen whatever the offset came out as.
+            if (IsAlreadyInSync(result)
+                && string.IsNullOrWhiteSpace(destinationOverride)
+                && outputFormat is null)
+            {
+                result.Skipped = true;
+                result.AlreadyInSync = true;
+
+                _logger.LogInformation(
+                    "{Engine} found {Subtitle} is already in sync (offset {Offset}ms, tolerance {Tolerance}ms) - leaving it alone",
+                    engine.Descriptor.DisplayName,
+                    subtitlePath,
+                    result.OffsetMs,
+                    Plugin.Instance?.Configuration.AlreadyInSyncToleranceMs);
+
+                return result;
+            }
+
             result.BackupPath = TakeBackup(destination, resolvedOutputMode);
 
             if (NeedsFormatChange(workPath, destination))
@@ -662,6 +684,40 @@ public class EngineRunner
         var backupPath = destination + ".bak";
         File.Copy(destination, backupPath, overwrite: true);
         return backupPath;
+    }
+
+    /// <summary>
+    /// Says whether the engine's answer amounts to "this was already fine". Deliberately
+    /// strict about what it will call a no-op: the offset has to be one the engine
+    /// actually reported (a null means it didn't say, which is not the same as zero), and
+    /// anything that stretches the subtitle or cuts it into pieces gets written no matter
+    /// how small the shift, because those change the timing across the file rather than
+    /// nudging the whole thing.
+    /// </summary>
+    /// <param name="result">A successful engine result.</param>
+    /// <returns>True if nothing worth writing came out of the run.</returns>
+    private static bool IsAlreadyInSync(SyncResult result)
+    {
+        var config = Plugin.Instance?.Configuration;
+        if (config?.SkipAlreadyInSync != true)
+        {
+            return false;
+        }
+
+        if (result.OffsetMs is not { } offset)
+        {
+            return false;
+        }
+
+        // A ratio correction moves later cues further than earlier ones, so a small
+        // offset says nothing about what the run would do to the end of the file.
+        if (result.Slope is not null || result.Mode == SyncMode.Split)
+        {
+            return false;
+        }
+
+        var tolerance = Math.Clamp(config.AlreadyInSyncToleranceMs, 0, 5000);
+        return Math.Abs(offset) <= tolerance;
     }
 
     private async Task<(string Stdout, string Stderr, int ExitCode)> RunProcessAsync(

--- a/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
+++ b/Jellyfin.Plugin.Lapse/Services/SyncQueueManager.cs
@@ -342,6 +342,13 @@ public class SyncQueueManager : IDisposable
     /// <returns>A line saying what happened and why.</returns>
     public static string DescribeSkip(SyncResult result)
     {
+        if (result.AlreadyInSync)
+        {
+            var tolerance = Plugin.Instance?.Configuration.AlreadyInSyncToleranceMs ?? 100;
+            return $"Already in sync (the engine would have moved it {result.OffsetMs}ms, which is inside the "
+                + $"{tolerance}ms tolerance), so the file was left exactly as it was.";
+        }
+
         var threshold = Plugin.Instance?.Configuration.ConfidenceSigma ?? LapseEngine.DefaultConfidenceSigma;
 
         // The engine's own words for what it thought of the answer. "nothing" means the
@@ -565,6 +572,10 @@ public class SyncQueueManager : IDisposable
 
         string? lastError = null;
         string? lastSkip = null;
+
+        // Set by a skip the engine wasn't sure about, as opposed to one that was skipped
+        // for being right already. Only the first kind leaves the item unfinished.
+        var doubted = false;
         SyncResult? lastResult = null;
         var syncedPaths = new List<string>();
 
@@ -650,6 +661,18 @@ public class SyncQueueManager : IDisposable
             else if (result.Skipped)
             {
                 lastSkip = DescribeSkip(result);
+
+                // Nothing was rewritten, but an already-in-sync subtitle is a correct
+                // subtitle, so it counts as done rather than leaving the item looking
+                // half finished on every run that goes past it.
+                if (result.AlreadyInSync)
+                {
+                    syncedPaths.Add(workPath);
+                }
+                else
+                {
+                    doubted = true;
+                }
             }
             else
             {
@@ -689,7 +712,10 @@ public class SyncQueueManager : IDisposable
             // The run worked, we just deliberately didn't write anything. Calling that
             // "Synced" would be a lie about what's on disk, and calling it "Failed" would
             // be a lie about the engine, so it stays pending with the reason attached.
-            SaveRecord(itemId, MovieSyncStatus.Pending, lastSkip, lastResult, syncedPaths);
+            // Unless nothing was written because every subtitle here was already right,
+            // which is the one skip that really is a finished item.
+            var status = doubted ? MovieSyncStatus.Pending : MovieSyncStatus.Synced;
+            SaveRecord(itemId, status, lastSkip, lastResult, syncedPaths);
             SetItemStatus(itemId, QueueItemStatus.Done);
             return true;
         }


### PR DESCRIPTION
A run over a whole library goes through plenty of subtitles that were fine to begin with. When the engine's answer is a plain shift under a configured tolerance (100ms by default), the file is now left exactly as it was - no rewrite, no backup, no sidecar - and it still counts as synced rather than leaving the item stuck on partly synced.

Stretched and split results are always written regardless of how small the offset looks, since those change timing across the whole file rather than moving it as one piece. On by default, with the tolerance configurable under File output.